### PR TITLE
Allow custom loaders

### DIFF
--- a/src/loader-categories.js
+++ b/src/loader-categories.js
@@ -6,11 +6,16 @@ import MissingView from './missing-view'
 export default class Loader extends Component {
 
   static loadProps({params, loadContext}, cb) {
+
     const customLoader = loadContext.loaders.Categories
     if (customLoader) return customLoader(loadContext.siteUrl, cb)
+
+    const baseUrl = `${loadContext.siteUrl}/wp-json/wp/v2`
+    const path = `posts?filter[category_name]=${params.subcategory || params.category}`
+
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it
-    return fetch(`${loadContext.siteUrl}/wp-json/wp/v2/posts?filter[category_name]=${params.subcategory || params.category}`)
+    return fetch(`${baseUrl}/${path}`)
       .then(response => response.json())
       .then(data => cb(null, { data }))
       .catch(error => cb(error))

--- a/src/loader-home.js
+++ b/src/loader-home.js
@@ -12,15 +12,15 @@ export default class Loader extends Component {
 
     const baseUrl = `${loadContext.siteUrl}/wp-json/wp/v2`
 
-    let url = `pages?filter[name]=home`
+    let path = `pages?filter[name]=home`
     if (parseInt(loadContext.frontPage))
-      url = `pages/${loadContext.frontPage}`
+      path = `pages/${loadContext.frontPage}`
     else if (typeof loadContext.frontPage === 'string')
-      url = `pages?filter[name]=${loadContext.frontPage}`
+      path = `pages?filter[name]=${loadContext.frontPage}`
 
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it
-    return fetch(`${baseUrl}/${url}`)
+    return fetch(`${baseUrl}/${path}`)
       .then(resp => resp.json())
       .then(resp => {
         const data = ('0' in resp) || resp instanceof Array ?

--- a/src/loader-page.js
+++ b/src/loader-page.js
@@ -6,11 +6,16 @@ import MissingView from './missing-view'
 export default class Loader extends Component {
 
   static loadProps({params, loadContext}, cb) {
+
     const customLoader = loadContext.loaders.Page
     if (customLoader) return customLoader(loadContext.siteUrl, cb)
+
+    const baseUrl = `${loadContext.siteUrl}/wp-json/wp/v2`
+    const path = `pages?filter[name]=${params.slug}`
+
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it
-    return fetch(`${loadContext.siteUrl}/wp-json/wp/v2/pages?filter[name]=${params.slug}`)
+    return fetch(`${baseUrl}/${path}`)
       .then(response => response.json())
       .then(data => cb(null, { data: data[0] }))
       .catch(error => cb(error))

--- a/src/loader-post.js
+++ b/src/loader-post.js
@@ -6,11 +6,16 @@ import MissingView from './missing-view'
 export default class Loader extends Component {
 
   static loadProps({params, loadContext}, cb) {
+
     const customLoader = loadContext.loaders.Post
     if (customLoader) return customLoader(loadContext.siteUrl, cb)
+
+    const baseUrl = `${loadContext.siteUrl}/wp-json/wp/v2`
+    const path = `posts/${params.id}?_embed`
+
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it
-    return fetch(`${loadContext.siteUrl}/wp-json/wp/v2/posts/${params.id}?_embed`)
+    return fetch(`${baseUrl}/${path}`)
       .then(response => response.json())
       .then(data => cb(null, { data }))
       .catch(error => cb(error))


### PR DESCRIPTION
A little thing to allow custom loaders to be passed to Tapestry. Naming is hard-coded and there's a bunch of duplicated code at the mo. Next step is probably to create a single 'loader' that calls specific `fetch()` functions for the views.

`tapestry.js`
```js
export default {
  components: {
    Base, Page, Post, Home
  },
  loaders: {
    Home: LoaderHome
  },
  siteUrl: 'http://shortliststudio.foundry.press'
}
```
`loaderHome.js`
```js
export default (url, cb) =>
  fetch(`${url}/super-custom-endpoint-that-overwrites-the-default`)
    .then(resp => resp.json())
    .then(data => cb(null, { data }))
    .catch(err => cb(err))
```