### PR TITLE
Switched the glamor method to renderStaticOptimized

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { renderToStaticMarkup, renderToString } from 'react-dom/server'
 import { match } from 'react-router'
 import Helmet from 'react-helmet'
-import { renderStatic } from 'glamor/server'
+import { renderStaticOptimized } from 'glamor/server'
 
 import { Server } from 'hapi'
 import h2o2 from 'h2o2'
@@ -113,12 +113,14 @@ export default class TapestryServer {
             if (err) console.log(err)
             // get html from props
             const data = {
-              markup: renderStatic(() => renderToString(
-                <AsyncProps
-                  {...renderProps}
-                  {...asyncProps}
-                  loadContext={loadContext} />
-              )),
+              markup: renderStaticOptimized(() =>
+                renderToString(
+                  <AsyncProps
+                    {...renderProps}
+                    {...asyncProps}
+                    loadContext={loadContext} />
+                )
+              ),
               head: Helmet.rewind(),
               asyncProps
             }


### PR DESCRIPTION
As per this issue https://github.com/shortlist-digital/tapestry-wp/issues/22

However this is still spitting out the entirety of the applications CSS, I read and re-read the Glamor docs but couldn't get it to work. The `rehydrate` method shouldn't have any impact on this, as far as I'm aware, but implementing exactly as per the docs still gives me more CSS than I want.