### PR TITLE
Update CLI, create separate scripts to handle different tasks

### DIFF
--- a/bin/tapestry
+++ b/bin/tapestry
@@ -1,43 +1,50 @@
 #!/usr/bin/env node
 
-const program = require('commander')
-const exec = require('child_process').exec
-const path = require('path')
-const webpack = require('webpack')
+'use strict'
 
+const path = require('path')
+const cp = require('child_process')
 const pkg = require('../package.json')
 
-const cwdCached = process.cwd()
+const defaultCommand = 'dev'
+const commands = [
+  'build',
+  'start',
+  defaultCommand
+]
 
-program
-  .version(pkg.version)
-  .command('build')
-  .action(function() {
-    process.chdir(path.join(__dirname, '..'))
-    exec('./node_modules/babel-cli/bin/babel.js ' + cwdCached + ' --out-dir ./dist/app --presets=es2015,react  --ignore node_modules,__tests__', (err, stdout, stderr) => {
-       if (err) {
-         console.error(err)
-         return
-       }
-       console.log(stdout)
-       console.log('Built Server')
-    })
-  })
+let cmd = process.argv[2]
 
-program
-  .command('start')
-  .action(function() {
-    global.TAPESTRY_PRODUCTION = true
-    require('../dist/boot.js')
-  })
-
-program.parse(process.argv)
-
-var NO_COMMAND_SPECIFIED = program.args.length === 0;
-
-if (NO_COMMAND_SPECIFIED) {
-  require('babel-register')({
-    "presets": ["es2015", "react"]
-  })
-  require('../dist/boot.js')
+if (['--version', '-v'].indexOf(cmd) !== -1) {
+  console.log(`tapestry-wp v${pkg.version}`)
+  process.exit(0)
 }
+
+if (['--help', '-h'].indexOf(cmd) !== -1) {
+  console.log(`
+    Usage
+      $ tapestry <command>
+
+    Available commands
+      ${Array.from(commands).join(', ')}
+  `)
+  process.exit(0)
+}
+
+if (commands.indexOf(cmd) === -1) {
+  cmd = defaultCommand
+}
+
+const bin = path.join(__dirname, `tapestry-${cmd}`)
+
+const startProcess = () => {
+  const proc = cp.spawn(bin, [], { stdio: 'inherit' })
+  proc.on('close', code => process.exit(code))
+  proc.on('error', err => {
+    console.error(err)
+    process.exit(1)
+  })
+  return proc
+}
+
+startProcess()

--- a/bin/tapestry-build
+++ b/bin/tapestry-build
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const cp = require('child_process')
+const path = require('path')
+
+const cwdCached = process.cwd()
+
+process.chdir(path.join(__dirname, '..'))
+cp.exec('./node_modules/babel-cli/bin/babel.js ' + cwdCached + ' --out-dir ./dist/app --presets=es2015,react  --ignore node_modules,__tests__', (err, stdout, stderr) => {
+  if (err) {
+    console.error(err)
+    return
+  }
+  console.log(stdout)
+  console.log('Built Server')
+})

--- a/bin/tapestry-dev
+++ b/bin/tapestry-dev
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+require('babel-register')({
+  "presets": ["es2015", "react"]
+})
+require('../dist/boot.js')

--- a/bin/tapestry-start
+++ b/bin/tapestry-start
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+global.TAPESTRY_PRODUCTION = true
+
+require('../dist/boot.js')


### PR DESCRIPTION
This is an update of the CLI for __tapestry-wp__ only, it still boots up the same build/start scripts as before. This follows the example set by __next__ – creating separate scripts to handle the different tasks. These will eventually be fleshed out like __next__, for now they just use the existing set up.

I've added `'use strict'` in some files that use `const`/`let` as I just ran this in Node v4.7 and got errors that those things can only be used in `strict mode`.