### PR TITLE
Hash bundle

### DIFF
--- a/bin/tapestry-build
+++ b/bin/tapestry-build
@@ -26,12 +26,20 @@ const noPublic = (file) => {
   return true
 }
 
+const noScripts = (file) => {
+  // Test if a file is in a public directory we don't want to transpile
+  if (/_scripts/.test(file.path)) {
+    file.exclude = true
+  }
+  return true
+}
+
 const transform = (filePath) => {
   babel.transformFile(`${cwd}/${filePath}`, { presets: ['es2015', 'react'] }, (err, result) => {
     if (err) {
       return logger.error(err)
     }
-    fs.writeFile(`${cwd}/.tapestry/${filePath}`, result.code, 'utf8', (err) => {
+    fs.writeFile(`${cwd}/.tapestry/app/${filePath}`, result.code, 'utf8', (err) => {
       if (err) {
         return logger.error(err)
       }
@@ -39,13 +47,11 @@ const transform = (filePath) => {
   })
 }
 
-glob.use(noTests).use(noPublic).readdir('**/*.js', function (err, files) {
+glob.use(noTests).use(noPublic).use(noScripts).readdir('**/*.js', function (err, files) {
   if (err) {
     logger.error(err)
   } else {
-    // Push tapestry.config.js manually as it is git ignored
-    files.push('tapestry.config.js')
-    files.map((file) => {
+    files.map((file, i) => {
       console.log(file)
       transform(file)
     })

--- a/bin/tapestry-dev
+++ b/bin/tapestry-dev
@@ -39,10 +39,5 @@ if (!_.has(config.default, 'siteUrl'))
 new Client({
   cwd,
   env,
-  onComplete: () =>
-    new Server({
-      cwd,
-      config,
-      env
-    })
+  onComplete: () => new Server({ cwd, env, config })
 })

--- a/bin/tapestry-dev
+++ b/bin/tapestry-dev
@@ -9,6 +9,7 @@ const Server = require('../dist/server').default
 const Client = require('../dist/build').default
 const logger = require('../dist/logger')
 const cwd = process.cwd()
+const env = 'development'
 
 // project tapestry config path
 const treeClient = path.join(cwd, 'tapestry.config.js')
@@ -37,6 +38,11 @@ if (!_.has(config.default, 'siteUrl'))
 // kick off client build & server
 new Client({
   cwd,
-  env: 'development',
-  onComplete: () => new Server({ cwd, config })
+  env,
+  onComplete: () =>
+    new Server({
+      cwd,
+      config,
+      env
+    })
 })

--- a/bin/tapestry-start
+++ b/bin/tapestry-start
@@ -8,6 +8,7 @@ const Server = require('../dist/server').default
 const Client = require('../dist/build').default
 const logger = require('../dist/logger')
 const cwd = process.cwd()
+const env = 'production'
 
 // compiled tapestry config path
 const treeServer = path.join(cwd, '.tapestry/tapestry.config.js')
@@ -23,6 +24,11 @@ const config = require(treeServer)
 // kick off client build & server
 new Client({
   cwd,
-  env: 'production',
-  onComplete: () => new Server({ cwd, config })
+  env,
+  onComplete: () =>
+    new Server({
+      cwd,
+      config,
+      env
+    })
 })

--- a/bin/tapestry-start
+++ b/bin/tapestry-start
@@ -25,10 +25,5 @@ const config = require(treeServer)
 new Client({
   cwd,
   env,
-  onComplete: () =>
-    new Server({
-      cwd,
-      config,
-      env
-    })
+  onComplete: () => new Server({ cwd, env, config })
 })

--- a/bin/tapestry-start
+++ b/bin/tapestry-start
@@ -11,7 +11,7 @@ const cwd = process.cwd()
 const env = 'production'
 
 // compiled tapestry config path
-const treeServer = path.join(cwd, '.tapestry/tapestry.config.js')
+const treeServer = path.join(cwd, '.tapestry/app/tapestry.config.js')
 
 // check compiled tapestry directory exists
 if (!fs.existsSync(treeServer))

--- a/src/default-html.js
+++ b/src/default-html.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react'
 import './default-style'
 
-const defaultHtml = ({ markup, head, asyncProps }) => {
+const defaultHtml = ({ markup, head, asyncProps, assets }) => {
   const attr = head.htmlAttributes.toComponent()
   return (
     <html lang="en" {...attr}>
@@ -11,7 +11,7 @@ const defaultHtml = ({ markup, head, asyncProps }) => {
         {head.meta.toComponent()}
         {head.link.toComponent()}
         {head.script.toComponent()}
-        <script defer src="/_scripts/bundle.js" />
+        <script defer src={`/_scripts/${assets ? assets.bundle : 'bundle.js'}`} />
         <style dangerouslySetInnerHTML={{ __html: markup.css }} />
         <link rel="shortcut icon" href="/public/favicon.ico" />
       </head>

--- a/src/server.js
+++ b/src/server.js
@@ -28,7 +28,7 @@ export default class Tapestry {
     this.env = env
     // override defaults
     this.routes = this.config.routes || DefaultRoutes
-    this.assets = fs.readJsonSync(path.resolve(cwd, 'node_modules/tapestry-wp/assets.json'), 'utf8')
+    this.assets = fs.readJsonSync(path.resolve(cwd, '.tapestry/assets.json'))
     // run server
     this.bootServer()
     this.registerProxies()

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+import fs from 'fs-extra'
+import path from 'path'
 import React from 'react'
 import { renderToStaticMarkup, renderToString } from 'react-dom/server'
 import { match } from 'react-router'
@@ -19,12 +21,14 @@ import { success, error, info } from './logger'
 
 export default class Tapestry {
 
-  constructor ({ config, cwd }) {
+  constructor ({ config, cwd, env }) {
     // allow access from class
     this.config = config.default
     this.context = cwd
+    this.env = env
     // override defaults
     this.routes = this.config.routes || DefaultRoutes
+    this.assets = fs.readJsonSync(path.resolve(cwd, 'node_modules/tapestry-wp/assets.json'), 'utf8')
     // run server
     this.bootServer()
     this.registerProxies()
@@ -156,6 +160,7 @@ export default class Tapestry {
                 )
               ),
               head: Helmet.rewind(),
+              assets: this.env === 'production' ? this.assets : null,
               asyncProps
             }
 

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -60,7 +60,6 @@ export default ({ cwd, env }) => {
       function () {
         this.plugin('done', stats => {
           const jsonStats = stats.toJson()
-          console.log(path.resolve(cwd, '.tapestry/assets.json'))
           return fs.writeFileSync(
             path.resolve(cwd, '.tapestry/assets.json'),
             JSON.stringify(jsonStats.assetsByChunkName)

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -6,10 +6,12 @@ import CleanPlugin from 'clean-webpack-plugin'
 export default ({ cwd, env }) => {
 
   const config = {
-    entry: 'tapestry-wp/dist/client.js',
+    entry: {
+      bundle: 'tapestry-wp/dist/client.js'
+    },
     output: {
       path: path.resolve(cwd, '_scripts'),
-      filename: 'bundle.js'
+      filename: '[name].js'
     },
     resolve: {
       alias: {
@@ -38,6 +40,7 @@ export default ({ cwd, env }) => {
   }
 
   if (env === 'production') {
+    config.output.filename = '[name].[chunkhash].js'
     config.resolve.alias = {
       'tapestry.config.js': path.resolve(cwd, '.tapestry/tapestry.config.js')
     }
@@ -55,12 +58,13 @@ export default ({ cwd, env }) => {
         debug: false
       }),
       function () {
-        this.plugin('done', stats =>
-          fs.writeFileSync(
-            path.resolve(cwd, 'stats.json'),
-            JSON.stringify(stats.toJson())
+        this.plugin('done', stats => {
+          const jsonStats = stats.toJson()
+          return fs.writeFileSync(
+            './node_modules/tapestry-wp/assets.json',
+            JSON.stringify(jsonStats.assetsByChunkName)
           )
-        )
+        })
       }
     )
   }

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -42,7 +42,7 @@ export default ({ cwd, env }) => {
   if (env === 'production') {
     config.output.filename = '[name].[chunkhash].js'
     config.resolve.alias = {
-      'tapestry.config.js': path.resolve(cwd, '.tapestry/tapestry.config.js')
+      'tapestry.config.js': path.resolve(cwd, '.tapestry/app/tapestry.config.js')
     }
     config.plugins.push(
       new webpack.DefinePlugin({
@@ -60,8 +60,9 @@ export default ({ cwd, env }) => {
       function () {
         this.plugin('done', stats => {
           const jsonStats = stats.toJson()
+          console.log(path.resolve(cwd, '.tapestry/assets.json'))
           return fs.writeFileSync(
-            './node_modules/tapestry-wp/assets.json',
+            path.resolve(cwd, '.tapestry/assets.json'),
             JSON.stringify(jsonStats.assetsByChunkName)
           )
         })


### PR DESCRIPTION
#### What have you done
Added `chunkhash` to output bundle name, shuffled around some of the output directories, transpiled component tree now lives under `.tapestry/app/` so our new `assets.json` can live in the `.tapestry` directory.

#### Why have you done it
This allows us to provide longterm caching of our output JS bundle.

#### Testing carried out to prevent breaking changes
Tested on our local Tapestry dev example project.