### PR TITLE
Add pre commit scripts

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -5,6 +5,7 @@
   ],
   "*.js": [
     "eslint --fix",
-    "git add"
+    "git add",
+    "npm test"
   ]
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,10 @@
+{
+  "*.{md,sh,txt,xml,html,json}": [
+    "editorconfig-tools fix",
+    "git add"
+  ],
+  "*.js": [
+    "eslint --fix",
+    "git add"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Wordpress API Universal React Renderer",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint src bin bootstrap test",
+    "lint": "eslint src bin bootstrap test --cache",
     "prepublish": "babel ./src --out-dir ./dist",
     "watch": "babel ./src --watch --out-dir ./dist",
-    "test": "mocha 'test/**/*.test.js' --compilers js:babel-core/register"
+    "test": "mocha 'test/**/*.test.js' --compilers js:babel-core/register",
+    "pre-commit-msg": "echo \"Performing pre-commit checks...\" && exit 0",
+    "lint-staged": "lint-staged"
   },
   "author": "Jon Sherrard",
   "license": "ISC",
@@ -53,9 +55,16 @@
     "webpack": "^2.2.0"
   },
   "devDependencies": {
+    "editorconfig-tools": "^0.1.1",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
     "nock": "^9.0.2",
-    "request": "^2.79.0"
-  }
+    "request": "^2.79.0",
+    "lint-staged": "^3.3.0",
+    "pre-commit": "^1.2.2"
+  },
+  "pre-commit": [
+    "pre-commit-msg",
+    "lint-staged"
+  ]
 }

--- a/src/build.js
+++ b/src/build.js
@@ -6,6 +6,7 @@ import { success, error } from './logger'
 export default class Build {
 
   constructor (opts) {
+    // this is a test comment
     // allow class access
     this.opts = opts
     this.compiler = webpack(config(opts))

--- a/src/build.js
+++ b/src/build.js
@@ -6,7 +6,6 @@ import { success, error } from './logger'
 export default class Build {
 
   constructor (opts) {
-    // this is a test comment
     // allow class access
     this.opts = opts
     this.compiler = webpack(config(opts))


### PR DESCRIPTION
#### What have you done
Added `pre-commit`, `lint-staged` and `editorconfig-tools` to allow pre-commit linting/testing

#### Why have you done it
It was real crummy committing/pushing/deploying code that broke tests, this will prevent any commits that fail tests or linting specs.