### PR TITLE
In memory caching of HTML render and API requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "joi": "^10.2.2",
     "location-origin": "^1.1.4",
     "lodash": "^4.17.4",
+    "lru-cache": "^4.0.2",
     "pretty-bytes": "^4.0.2",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -2,7 +2,6 @@
 import LRU from 'lru-cache'
 import fetch from 'isomorphic-fetch'
 
-
 export default ({ server, config }) => {
 
   // Create a new cache | 100 requests only, expire after 2 minutes

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -1,13 +1,39 @@
 
+import LRU from 'lru-cache'
+import fetch from 'isomorphic-fetch'
+
+// Create a new cache | 100 requests only, expire after 2 minutes
+const cache = LRU({
+  max: 100,
+  maxAge: 1000*60*2
+})
+
 export default ({ server, config }) => {
 
   server.route({
     method: 'GET',
     path: '/api/v1/{query*}',
-    handler: {
-      proxy: {
-        mapUri: (req, cb) =>
-          cb(null, `${config.siteUrl}/wp-json/wp/v2/${req.params.query}${req.url.search}`)
+    handler: (req, reply) => {
+      const remote = `${config.siteUrl}/wp-json/wp/v2/${req.params.query}${req.url.search}`
+      // Look for a cached response - maybe undefined
+      const cacheResponse = cache.get(remote)
+      // If we find a response in the cache send it back
+      if (cacheResponse) {
+        console.log(`Loaded response from cache: ${remote}`)
+        reply(cacheResponse)
+      } else {
+        fetch(remote)
+          .then(response => response.json())
+          .then(resp => {
+            const data = ('0' in resp) || resp instanceof Array ?
+              resp[0] :
+              resp
+            // We can only get here if there's nothing cached
+            // Put the response into the cache using the request path as a key
+            cache.set(remote, data)
+            console.log(`Loaded response from API: ${remote}`)
+            reply(data)
+        })
       }
     }
   })

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -2,13 +2,18 @@
 import LRU from 'lru-cache'
 import fetch from 'isomorphic-fetch'
 
-// Create a new cache | 100 requests only, expire after 2 minutes
-const cache = LRU({
-  max: 100,
-  maxAge: 1000*60*2
-})
 
 export default ({ server, config }) => {
+
+  // Create a new cache | 100 requests only, expire after 2 minutes
+  const cache = LRU({
+    max: 100,
+    maxAge: 1000*60*2
+  })
+
+  server.on('reset-cache', () => {
+    cache.reset()
+  })
 
   server.route({
     method: 'GET',
@@ -19,7 +24,6 @@ export default ({ server, config }) => {
       const cacheResponse = cache.get(remote)
       // If we find a response in the cache send it back
       if (cacheResponse) {
-        console.log(`Loaded response from cache: ${remote}`)
         reply(cacheResponse)
       } else {
         fetch(remote)
@@ -31,9 +35,8 @@ export default ({ server, config }) => {
             // We can only get here if there's nothing cached
             // Put the response into the cache using the request path as a key
             cache.set(remote, data)
-            console.log(`Loaded response from API: ${remote}`)
             reply(data)
-        })
+          })
       }
     }
   })

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -11,9 +11,7 @@ export default ({ server, config }) => {
     maxAge: 1000*60*2
   })
 
-  server.on('reset-cache', () => {
-    cache.reset()
-  })
+  server.on('reset-cache', cache.reset)
 
   server.route({
     method: 'GET',

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -1,16 +1,11 @@
 
-import LRU from 'lru-cache'
 import fetch from 'isomorphic-fetch'
+import CacheManager from '../utilities/cache-manager'
 
 export default ({ server, config }) => {
 
   // Create a new cache | 100 requests only, expire after 2 minutes
-  const cache = LRU({
-    max: 100,
-    maxAge: 1000*60*2
-  })
-
-  server.on('reset-cache', cache.reset)
+  const cache = CacheManager.createCache('api')
 
   server.route({
     method: 'GET',

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -7,14 +7,21 @@ import { renderHtml } from './render'
 import { error } from '../utilities/logger'
 import LRU from 'lru-cache'
 
-// Create a new cache | 100 pages only, expire after 2 minutes
-const cache = LRU({
-  max: 100,
-  maxAge: 1000*60*2
-})
+
 
 
 export default ({ server, config, assets }) => {
+
+  // Create a new cache | 100 pages only, expire after 2 minutes
+  const cache = LRU({
+    max: 100,
+    maxAge: 1000*60*2
+  })
+
+  // Reset the cache on global server event
+  server.on('reset-cache', () => {
+    cache.reset()
+  })
 
   server.route({
     method: 'GET',
@@ -70,7 +77,6 @@ export default ({ server, config, assets }) => {
 
           // respond with HTML from cache if not undefined
           if (cachedHTML) {
-            console.log(`Server HTML from cache: ${request.url.path}`)
             reply(cachedHTML).code(status)
           } else {
             // No HTML found for this path, or cache expired
@@ -83,7 +89,6 @@ export default ({ server, config, assets }) => {
             })
 
             // 200 with rendered HTML
-            console.log(`Server HTML from renderHTML call: ${request.url.path}`)
             // We can only get here if there's nothing cached for this URL path
             // Bung the HTML into the cache
             cache.set(request.url.path, html)

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -5,18 +5,12 @@ import { has } from 'lodash'
 import DefaultRoutes from '../shared/default-routes'
 import { renderHtml } from './render'
 import { error } from '../utilities/logger'
-import LRU from 'lru-cache'
+import CacheManager from '../utilities/cache-manager'
 
 export default ({ server, config, assets }) => {
 
-  // Create a new cache | 100 pages only, expire after 2 minutes
-  const cache = LRU({
-    max: 100,
-    maxAge: 1000*60*2
-  })
-
-  // Reset the cache on global server event
-  server.on('reset-cache', cache.reset)
+  // Create a new cache
+  const cache = CacheManager.createCache('html')
 
   server.route({
     method: 'GET',

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -19,9 +19,7 @@ export default ({ server, config, assets }) => {
   })
 
   // Reset the cache on global server event
-  server.on('reset-cache', () => {
-    cache.reset()
-  })
+  server.on('reset-cache', cache.reset)
 
   server.route({
     method: 'GET',

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -7,9 +7,6 @@ import { renderHtml } from './render'
 import { error } from '../utilities/logger'
 import LRU from 'lru-cache'
 
-
-
-
 export default ({ server, config, assets }) => {
 
   // Create a new cache | 100 pages only, expire after 2 minutes

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -20,6 +20,9 @@ export default class Tapestry {
     // create server instance
     this.server = this.bootServer()
 
+    // register reset-cache event
+    this.server.event('reset-cache')
+
     // handle server routing
     const data = {
       server: this.server,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,6 +7,7 @@ import handleStatic from './handle-static'
 import handleApi from './handle-api'
 import handleDynamic from './handle-dynamic'
 import handleProxies from './handle-proxies'
+import CacheManager from '../utilities/cache-manager'
 
 
 export default class Tapestry {
@@ -22,6 +23,8 @@ export default class Tapestry {
 
     // register reset-cache event
     this.server.event('reset-cache')
+    // Clear all caches on reset-cache event
+    this.server.on('reset-cache', CacheManager.clearAll)
 
     // handle server routing
     const data = {

--- a/src/utilities/cache-manager.js
+++ b/src/utilities/cache-manager.js
@@ -1,0 +1,20 @@
+import LRU from 'lru-cache'
+
+const internalCaches = []
+
+export default class CacheManager {
+
+  static createCache(name) {
+    internalCaches[name] = LRU({
+      max: 100,
+      maxAge: process.env.CACHE_MAX_AGE || 1000*60*2
+    })
+    return internalCaches[name]
+  }
+
+  static clearAll() {
+    internalCaches.forEach(cache =>
+      cache.reset()
+    )
+  }
+}

--- a/src/utilities/cache-manager.js
+++ b/src/utilities/cache-manager.js
@@ -4,15 +4,16 @@ const internalCaches = []
 
 export default class CacheManager {
 
-  static createCache(name) {
+  static createCache (name) {
     internalCaches[name] = LRU({
       max: 100,
-      maxAge: process.env.CACHE_MAX_AGE || 1000*60*2
+      maxAge: (process.env.NODE_ENV === 'production') ?
+        (process.env.CACHE_MAX_AGE || 1000*60*2) : 0
     })
     return internalCaches[name]
   }
 
-  static clearAll() {
+  static clearAll () {
     internalCaches.forEach(cache =>
       cache.reset()
     )

--- a/src/utilities/cache-manager.js
+++ b/src/utilities/cache-manager.js
@@ -8,7 +8,7 @@ export default class CacheManager {
     internalCaches[name] = LRU({
       max: 100,
       maxAge: (process.env.NODE_ENV === 'production') ?
-        (process.env.CACHE_MAX_AGE || 1000*60*2) : 0
+        (process.env.CACHE_MAX_AGE || 1000*60*2) : 1
     })
     return internalCaches[name]
   }

--- a/test/tests/document.test.js
+++ b/test/tests/document.test.js
@@ -18,12 +18,16 @@ describe('HTML document', () => {
   }
 
 
-  before(done => {
+  beforeEach(done => {
     mockApi()
     tapestry = bootServer(config)
     tapestry.server.on('start', done)
   })
-  after(() => tapestry.server.stop())
+
+  afterEach(() => {
+    tapestry.server.emit('reset-cache')
+    tapestry.server.stop()
+  })
 
 
   it('Data is correctly loaded on page', (done) => {


### PR DESCRIPTION
#### What have you done
I've added an in [memory cache](https://github.com/isaacs/node-lru-cache). It will cache the last 100 responses to the API and the renderHTML method, for 2 minutes each

#### Why have you done it
This drastically improves response times for the top 100 hit pages of a Tapestry site

#### Testing
The end-to-end integration tests still work, and there's not much code here so I feel like restructuring, code into unit testable methods (assert "loadFromCache" was called etc) would be testing node-lru-cache rather than tapestry.
