### PR TITLE
Allow async static routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-core": "^6.23.1",
     "babel-loader": "^6.3.2",
     "babel-plugin-lodash": "^3.2.11",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -56,9 +56,9 @@ export default class Client {
 
   logAssets (stats) {
     // return line-break and indented
+    // stats.json shouldn't be shared with user
     return stats.assets
-      .map(asset => asset.chunkNames.length > 0 &&
-        `\n    ${asset.name} ${bytes(asset.size)}`)
-      .filter(Boolean)
+      .filter(asset => !asset.name.includes('stats.json'))
+      .map(asset => `\n    ${asset.name} ${bytes(asset.size)}`)
   }
 }

--- a/src/client/webpack.entry.js
+++ b/src/client/webpack.entry.js
@@ -1,25 +1,31 @@
 import React from 'react'
 import { render } from 'react-dom'
-import { Router, browserHistory } from 'react-router'
+import { Router, match, browserHistory } from 'react-router'
 import AsyncProps from 'async-props'
 import 'location-origin'
-
 import DefaultRoutes from '../shared/default-routes'
 import config from 'tapestry.config.js'
 
-let onUpdateMethod = () => {}
-if (typeof config.onPageUpdate === 'function') {
-  onUpdateMethod = config.onPageUpdate
-}
+// methods in use on the <Router />
+const onUpdate = () =>
+  typeof config.onPageUpdate === 'function' && config.onPageUpdate
 const renderAsyncProps = props =>
   <AsyncProps loadContext={config} {...props} />
 
-render(
-  <Router
-    onUpdate={onUpdateMethod}
-    history={browserHistory}
-    render={renderAsyncProps}
-    routes={DefaultRoutes(config)}>
-  </Router>,
-  document.getElementById('root')
+// define routes/history for react-router
+const routes = DefaultRoutes(config)
+const history = browserHistory
+const targetNode = document.getElementById('root')
+
+// run a router match (not sure why this is necessary)
+match({ routes, history }, (error, redirectLocation, renderProps) =>
+  render(
+    <Router
+      onUpdate={onUpdate}
+      render={renderAsyncProps}
+      routes={routes}
+      {...renderProps}
+    />,
+    targetNode
+  )
 )

--- a/src/server/render/default-html.js
+++ b/src/server/render/default-html.js
@@ -3,6 +3,7 @@ import './default-style'
 
 const defaultHtml = ({ markup, head, asyncProps, assets = {} }) => {
   const attr = head.htmlAttributes.toComponent()
+  const hasProps = asyncProps.propsArray.length > 0
   return (
     <html lang="en" {...attr}>
       <head>
@@ -18,7 +19,7 @@ const defaultHtml = ({ markup, head, asyncProps, assets = {} }) => {
       </head>
       <body>
         <div id="root" dangerouslySetInnerHTML={{ __html: markup.html }} />
-        <script dangerouslySetInnerHTML={{ __html: `window.__ASYNC_PROPS__ = ${JSON.stringify(asyncProps.propsArray)}` }} />
+        { hasProps && <script dangerouslySetInnerHTML={{ __html: `window.__ASYNC_PROPS__ = ${JSON.stringify(asyncProps.propsArray)}` }} /> }
       </body>
     </html>
   )

--- a/src/shared/default-routes.js
+++ b/src/shared/default-routes.js
@@ -22,41 +22,53 @@ const DefaultRoutes = ({
   } = components
   const Error = components.Error || MissingView
 
-  // return Route with component directly
-  const renderStaticRoute = (route, i) =>
-    <Route
-      component={route.component}
-      key={i}
-      path={route.path} />
+  // return static Route with component directly
+  const renderStaticRoute = (route, i) => {
+    // on 'route' event:
+    // getComponent will fetch the component async
+    // component will read the component from the bundle
+    const component = route.getComponent ?
+      { getComponent: (loc, cb) => route.getComponent(loc, cb) } :
+      { component: route.component }
+    // return static route with async or bundled component
+    return (
+      <Route
+        key={i}
+        path={route.path}
+        {...component} />
+    )
+  }
 
-  return (<div>
-    {
-      routes.map(renderStaticRoute)
-    }
-    <Route
-      path='/'
-      component={FrontPageLoader}
-      tag={FrontPage}
-      fallback={Error} />
-    <Route
-      path='about/:slug'
-      component={PageLoader}
-      tag={Page}
-      fallback={Error} />
-    <Route
-      path=':category(/:subcategory)'
-      component={CategoriesLoader}
-      tag={Category}
-      fallback={Error} />
-    <Route
-      path=':category(/:subcategory)/:slug/:id'
-      component={PostLoader}
-      tag={Post}
-      fallback={Error} />
-    <Route
-      path='*'
-      component={Error} />
-  </div>)
+  return (
+    <div>
+      {
+        routes.map(renderStaticRoute)
+      }
+      <Route
+        path='/'
+        component={FrontPageLoader}
+        tag={FrontPage}
+        fallback={Error} />
+      <Route
+        path='about/:slug'
+        component={PageLoader}
+        tag={Page}
+        fallback={Error} />
+      <Route
+        path=':category(/:subcategory)'
+        component={CategoriesLoader}
+        tag={Category}
+        fallback={Error} />
+      <Route
+        path=':category(/:subcategory)/:slug/:id'
+        component={PostLoader}
+        tag={Post}
+        fallback={Error} />
+      <Route
+        path='*'
+        component={Error} />
+    </div>
+  )
 }
 
 DefaultRoutes.propTypes = {

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -24,8 +24,9 @@ const schema = joi.object({
   routes: joi.array().items(
     // object containing a string path and React component
     joi.object({
-      path: joi.string(),
-      component: joi.func()
+      component: joi.func(),
+      getComponent: joi.func(),
+      path: joi.string()
     })
   ),
   // optional array of proxy paths

--- a/src/webpack/shared.js
+++ b/src/webpack/shared.js
@@ -7,7 +7,7 @@ module.exports = {
         loader: 'babel-loader',
         options: {
           presets: ['es2015', 'react'],
-          plugins: ['lodash', 'transform-object-rest-spread']
+          plugins: ['lodash', 'transform-object-rest-spread', 'syntax-dynamic-import']
         }
       }]
     }]

--- a/test/tests/routing.test.js
+++ b/test/tests/routing.test.js
@@ -15,6 +15,9 @@ describe('Custom routes', () => {
     }, {
       path: 'static-route-with-param/:custom',
       component: (props) => <p>{props.params.custom}</p>
+    }, {
+      path: 'static-route-async',
+      component: () => <p>This is async</p>
     }],
     siteUrl: 'http://dummy.api'
   }
@@ -38,6 +41,13 @@ describe('Custom routes', () => {
     request
       .get(`${tapestry.server.info.uri}/static-route-with-param/test-parameter`, (err, res, body) => {
         expect(body).to.contain('test-parameter')
+        done()
+      })
+  })
+  it('Static route matches, returns async component', (done) => {
+    request
+      .get(`${tapestry.server.info.uri}/static-route-async`, (err, res, body) => {
+        expect(body).to.contain('This is async')
         done()
       })
   })


### PR DESCRIPTION
#### What have you done
Static routes can now be asynchronously loaded via code-splitting.
```js
export default {
  routes: [{
    path: 'async-path-yo',
    getComponent: (loc, cb) =>
      import('./path/to/component.js')
        .then(module => cb(null, module.default))
        .catch(err => console.error(err))
  }],
  siteUrl: 'http://url'
}
```

#### Why have you done it
The less JS we load the better!

#### Testing carried out to prevent breaking changes
Added a test