### PR TITLE
!MERGE: Removed scrollTo and fixed onPageUpdate so the supplied method is called

### DIFF
--- a/src/client/webpack.entry.js
+++ b/src/client/webpack.entry.js
@@ -8,7 +8,7 @@ import config from 'tapestry.config.js'
 
 // methods in use on the <Router />
 const onUpdate = () =>
-  typeof config.onPageUpdate === 'function' && config.onPageUpdate
+  typeof config.onPageUpdate === 'function' && config.onPageUpdate()
 const renderAsyncProps = props =>
   <AsyncProps loadContext={config} {...props} />
 

--- a/src/shared/loader-categories.js
+++ b/src/shared/loader-categories.js
@@ -29,9 +29,6 @@ export default class Loader extends Component {
   }
 
   render () {
-
-    if (typeof window !== 'undefined') { window.scrollTo(0, 0) }
-
     const Tag = this.props.route.tag
     const Error = this.props.route.fallback
 

--- a/src/shared/loader-front-page.js
+++ b/src/shared/loader-front-page.js
@@ -32,9 +32,6 @@ export default class Loader extends Component {
   }
 
   render () {
-
-    if (typeof window !== 'undefined') { window.scrollTo(0, 0) }
-
     const Tag = this.props.route.tag
     const Error = this.props.route.fallback
 

--- a/src/shared/loader-page.js
+++ b/src/shared/loader-page.js
@@ -29,9 +29,6 @@ export default class Loader extends Component {
   }
 
   render () {
-
-    if (typeof window !== 'undefined') { window.scrollTo(0, 0) }
-
     const Tag = this.props.route.tag
     const Error = this.props.route.fallback
 

--- a/src/shared/loader-post.js
+++ b/src/shared/loader-post.js
@@ -29,9 +29,6 @@ export default class Loader extends Component {
   }
 
   render () {
-
-    if (typeof window !== 'undefined') { window.scrollTo(0, 0) }
-
     const Tag = this.props.route.tag
     const Error = this.props.route.fallback
 


### PR DESCRIPTION
#### What have you done
Removed loader references to window.scrollTo, I've seen weird visual bugs, and I feel like it's being called multiple times as pages switch around. 

It should be defined in use land in the supplied `onPageUpdate` method.

This wasn't actually being called - so I've fixed that too.

This contains the code that is experiencing issue: https://github.com/shortlist-digital/tapestry-wp/issues/94

