### PR TITLE
Initial work on redirect handler

### DIFF
--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -16,6 +16,7 @@ export default ({ server, config, assets }) => {
     method: 'GET',
     path: '/{path*}',
     handler: (request, reply) => {
+
       match({
         routes: DefaultRoutes(config),
         location: request.url.path

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -16,7 +16,6 @@ export default ({ server, config, assets }) => {
     method: 'GET',
     path: '/{path*}',
     handler: (request, reply) => {
-
       match({
         routes: DefaultRoutes(config),
         location: request.url.path

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -1,0 +1,17 @@
+
+export default ({ server, config }) => {
+  if (!config.redirectPaths) return
+
+  Object.keys(config.redirectPaths).forEach(fromPath => {
+    server.route({
+      method: 'GET',
+      path: `${fromPath}`,
+      handler: (request, reply) => {
+        reply
+          .redirect(config.redirectPaths[fromPath])
+          .permanent()
+          .rewritable(false)
+      }
+    })
+  })
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,6 +7,7 @@ import handleStatic from './handle-static'
 import handleApi from './handle-api'
 import handleDynamic from './handle-dynamic'
 import handleProxies from './handle-proxies'
+import handleRedirects from './handle-redirects'
 import CacheManager from '../utilities/cache-manager'
 
 export default class Tapestry {
@@ -38,6 +39,7 @@ export default class Tapestry {
       config: this.config,
       assets
     }
+    handleRedirects(data)
     handleStatic(data)
     handleApi(data)
     handleProxies(data)

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -38,6 +38,8 @@ const schema = joi.object({
   }),
   // optional array of proxy paths
   proxyPaths: joi.array().items(joi.string()),
+  // optional object of redirects
+  redirectPaths: joi.object(),
   // optional function run when routing on the client
   onPageUpdate: joi.func()
 })

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -19,12 +19,15 @@ describe('Handling redirects', () => {
   })
   after(() => tapestry.server.stop())
 
-  it('Redirect should return 301 status', (done) => {
-    // Can't work out how to get the intermediate 30x reply status
-    done()
+  // http://stackoverflow.com/questions/42136829/whats-difference-between-http-301-and-308-status-codes
+  it('Redirect should return 308 status', (done) => {
+    tapestry.server.inject(tapestry.server.info.uri + '/redirect/from/this-path', (res) => {
+          expect(res.statusCode).to.equal(308)
+          done()
+        })
   })
 
-  it('Redirect should to about/home with corrent content', (done) => {
+  it('Redirect should end up at about/home with correct content', (done) => {
     request
       .get(tapestry.server.info.uri + '/redirect/from/this-path', (err, res, body) => {
           expect(body).to.contain('dog named Jack')

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -1,0 +1,35 @@
+import { expect } from 'chai'
+import request from 'request'
+import { bootServer, mockProxy, mockApi } from '../utils'
+
+describe('Handling redirects', () => {
+
+  let tapestry = null
+  let config = {
+    redirectPaths: {
+      '/redirect/from/this-path': '/about/home'
+    },
+    siteUrl: 'http://dummy.api'
+  }
+
+  before(done => {
+    mockApi()
+    tapestry = bootServer(config)
+    tapestry.server.on('start', done)
+  })
+  after(() => tapestry.server.stop())
+
+  it('Redirect should return 301 status', (done) => {
+    // Can't work out how to get the intermediate 30x reply status
+    done()
+  })
+
+  it('Redirect should to about/home with corrent content', (done) => {
+    request
+      .get(tapestry.server.info.uri + '/redirect/from/this-path', (err, res, body) => {
+          expect(body).to.contain('dog named Jack')
+          expect(res.statusCode).to.equal(200)
+          done()
+        })
+  })
+})


### PR DESCRIPTION
#### What have you done
Added server-side redirect paths for Tapestry. Validator for the config and tests.

#### Why have you done it
Projects should be able to configure server-side only redirects.

#### Testing carried out to prevent breaking changes
New tests written, all tests passing. Testing is great. This _demonstrably works_ without unintended side-effects. 

