### PR TITLE
1st-party scripts can now run before 3rd party scripts

### DIFF
--- a/src/server/render/default-html.js
+++ b/src/server/render/default-html.js
@@ -11,9 +11,9 @@ const defaultHtml = ({ markup, head, asyncProps, assets = {} }) => {
         { head.base.toComponent() }
         { head.meta.toComponent() }
         { head.link.toComponent() }
-        { head.script.toComponent() }
         { assets.vendor && <script defer src={assets.vendor.js} /> }
         { assets.bundle && <script defer src={assets.bundle.js} /> }
+        { head.script.toComponent() }
         <style dangerouslySetInnerHTML={{ __html: markup.css }} />
         <link rel="shortcut icon" href="/public/favicon.ico" />
       </head>
@@ -33,7 +33,7 @@ defaultHtml.propTypes = {
   }).isRequired,
   head: PropTypes.object.isRequired,
   asyncProps: PropTypes.shape({
-    propsArray: PropTypes.array.isRequired
+    propsArray: PropTypes.array
   }),
   assets: PropTypes.object
 }


### PR DESCRIPTION
#### What have you done
Moved our `vendor`/`bundle` JS above any 3rd party JS declared through `react-helmet`

#### Why have you done it
There was no way to load a script through `react-helmet` and have it load after the `vendor`/`bundle`

#### Testing carried out to prevent breaking changes
No tests broken