### PR TITLE
Replace default routing with WordPress defaults

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -39,8 +39,8 @@ export default class Tapestry {
       assets
     }
     handleStatic(data)
-    handleApi(data)
     handleProxies(data)
+    handleApi(data)
     handleDynamic(data)
 
     // kick off server

--- a/src/shared/default-routes.js
+++ b/src/shared/default-routes.js
@@ -50,17 +50,17 @@ const DefaultRoutes = ({
         tag={FrontPage}
         fallback={Error} />
       <Route
-        path='about/:slug'
+        path=':page(/:subpage)'
         component={PageLoader}
         tag={Page}
         fallback={Error} />
       <Route
-        path=':category(/:subcategory)'
+        path='/category/:category(/:subcategory)'
         component={CategoriesLoader}
         tag={Category}
         fallback={Error} />
       <Route
-        path=':category(/:subcategory)/:slug/:id'
+        path='/:year/:monthnum/:day/:postname'
         component={PostLoader}
         tag={Post}
         fallback={Error} />

--- a/src/shared/loader-categories.js
+++ b/src/shared/loader-categories.js
@@ -13,7 +13,7 @@ export default class Loader extends Component {
     if (customLoader) return customLoader(loadContext.siteUrl, cb)
 
     const baseUrl = `${loadContext.siteUrl}/wp-json/wp/v2`
-    const path = `posts?filter[category_name]=${params.subcategory || params.category}`
+    const path = `posts?filter[category_name]=${params.subcategory || params.category}?_embed`
 
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it

--- a/src/shared/loader-front-page.js
+++ b/src/shared/loader-front-page.js
@@ -14,11 +14,11 @@ export default class Loader extends Component {
 
     const baseUrl = `${loadContext.serverUri || window.location.origin}/api/v1`
 
-    let path = `pages?filter[name]=home`
+    let path = `pages?slug=home&_embed`
     if (parseInt(loadContext.frontPage))
       path = `pages/${loadContext.frontPage}`
     else if (typeof loadContext.frontPage === 'string')
-      path = `pages?filter[name]=${loadContext.frontPage}`
+      path = `pages?slug=${loadContext.frontPage}`
 
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it

--- a/src/shared/loader-page.js
+++ b/src/shared/loader-page.js
@@ -13,7 +13,8 @@ export default class Loader extends Component {
     if (customLoader) return customLoader(loadContext, cb)
 
     const baseUrl = `${loadContext.serverUri||window.location.origin}`
-    const path = `api/v1/pages?filter[name]=${params.slug}`
+    const slug = params.subpage || params.page
+    const path = `api/v1/pages?slug=${slug}&_embed`
 
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it

--- a/src/shared/loader-post.js
+++ b/src/shared/loader-post.js
@@ -13,7 +13,7 @@ export default class Loader extends Component {
     if (customLoader) return customLoader(loadContext, cb)
 
     const baseUrl = `${loadContext.serverUri || window.location.origin}`
-    const path = `api/v1/posts/${params.id}?_embed`
+    const path = `api/v1/posts?slug=${params.postname}?_embed`
 
     // LoadContext is basicaly an object we can pass around
     // the sever with our components and some baseUrl on it

--- a/test/tests/component.test.js
+++ b/test/tests/component.test.js
@@ -45,7 +45,7 @@ describe('Components', () => {
   })
   it('Helmet <head> is rendered', (done) => {
     request
-      .get(`${tapestry.server.info.uri}/cat/slug/10`, (err, res, body) => {
+      .get(`${tapestry.server.info.uri}/2017/01/01/slug`, (err, res, body) => {
         expect(body).to.contain('Content in title tag')
         done()
       })

--- a/test/tests/document.test.js
+++ b/test/tests/document.test.js
@@ -46,7 +46,7 @@ describe('HTML document', () => {
   })
   it('Page should render project Glamor CSS', (done) => {
     request
-      .get(`${tapestry.server.info.uri}/cat/slug/10`, (err, res, body) => {
+      .get(`${tapestry.server.info.uri}/2017/01/01/slug`, (err, res, body) => {
         expect(body).to.contain(color)
         done()
       })

--- a/test/tests/proxies.test.js
+++ b/test/tests/proxies.test.js
@@ -12,7 +12,6 @@ describe('Handling proxies', () => {
     siteUrl: 'http://dummy.api'
   }
 
-
   before(done => {
     mockApi()
     mockProxy({
@@ -22,6 +21,7 @@ describe('Handling proxies', () => {
     tapestry = bootServer(config)
     tapestry.server.on('start', done)
   })
+
   after(() => tapestry.server.stop())
 
   it('Proxy should return correct content', (done) => {
@@ -31,6 +31,7 @@ describe('Handling proxies', () => {
           done()
         })
   })
+
   it('Undeclared proxy should return 404', (done) => {
     request
       .get(`${tapestry.server.info.uri}/test.txt`, (err, res) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -19,18 +19,20 @@ export const bootServer = (config) =>
 export const mockApi = () =>
   nock('http://dummy.api')
 
-    .get('/wp-json/wp/v2/pages')
-    .times(5)
-    .query({ filter: { name: 'home' }})
-    .reply(200, data)
-
-    .get('/wp-json/wp/v2/posts/10?_embed')
+    .get('/wp-json/wp/v2/pages?slug=home&_embed')
     .times(5)
     .reply(200, data)
 
-    .get('/wp-json/wp/v2/pages')
+    .get('/wp-json/wp/v2/posts?slug=slug?_embed')
     .times(5)
-    .query({ filter: { name: 'null-page' }})
+    .reply(200, data)
+
+    .get('/wp-json/wp/v2/pages?slug=test.txt&_embed')
+    .times(5)
+    .reply(404, dataError)
+
+    .get('/wp-json/wp/v2/pages?slug=null-page&_embed')
+    .times(5)
     .reply(404, dataError)
 
     .get('/wp-json/wp/v2/posts')


### PR DESCRIPTION
#### What have you done
I've updated the default routes and loading schemas to match the WordPress defaults for Permalinks and the mock API to represent the WP-API as of version `4.7.3`A

Post: `/year/month/day/post-slug`
Category: `/category/my-category-name/sub-category`
Pages: `/page-slug/sub-page-slug`

// Todo
Tag: `/tag/post-tag-slug`
Author: `/author/author-slug`

#### Why have you done it
Forces us to look at customisable routing, and also allows more WordPress sites to work out of the box. It also ties in with the quick-start section of the documentation 

#### Testing carried out to prevent breaking changes
All test passing.
