### PR TITLE
Deprecate config options

### DIFF
--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -10,8 +10,10 @@ const schema = joi.object({
   host: joi.string(),
   // optional number e.g. 3030
   port: joi.number(),
-  // optional number for page id or string for page name
-  frontPage: [joi.number(), joi.string()],
+  // DEPRECATED optional number for page id or string for page name
+  frontPage: joi.any().forbidden().error(
+    new Error('frontPage has been deprecated in favour of custom routes, read more at tapestry-wp.js.org')
+  ),
   // optional object containing React components
   components: joi.object().keys({
     Category: joi.func(),
@@ -48,7 +50,9 @@ const schema = joi.object({
 
 const logErrors = (err) => {
   // for each error message, output to console
-  logErrorObject({message: `There are some issues with your tapestry.config.js\n ${err.details.reduce((prev, item) => `${prev}\n  ${item.message}`, '')}`})
+  logErrorObject({
+    message: `There are some issues with your tapestry.config.js\n ${err.details.reduce((prev, item) => `${prev}\n  ${item.message}`, '')}`
+  })
 }
 
 const validator = (config, cb) => {

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -1,5 +1,5 @@
 import joi from 'joi'
-import { logErrorObject } from './logger'
+import { errorMessage } from './logger'
 
 
 // define valid config schema
@@ -43,9 +43,7 @@ const schema = joi.object({
 
 const logErrors = (err) => {
   // for each error message, output to console
-  logErrorObject({
-    message: `There are some issues with your tapestry.config.js\n ${err.details.reduce((prev, item) => `${prev}\n  ${item.message}`, '')}`
-  })
+  errorMessage(`There are some issues with your tapestry.config.js\n ${err.details.reduce((prev, item) => `${prev}\n  ${item.message}`, '')}`)
 }
 
 const validator = (config, cb) => {

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -2,6 +2,16 @@ import joi from 'joi'
 import { errorMessage } from './logger'
 
 
+const options = {
+  abortEarly: false, // we want all the errors, not just the first
+  language: {
+    any: {
+      unknown: 'has been deprecated, refer to tapestry-wp.js.org for config options'
+    }
+  }
+}
+
+
 // define valid config schema
 const schema = joi.object({
   // DEPRECATED optional number for page id or string for page name
@@ -49,9 +59,7 @@ const logErrors = (err) => {
 const validator = (config, cb) => {
   // run the users config object through joi.validate
   // joi will parse the config and match the defined schema
-  joi.validate(config, schema, {
-    abortEarly: false // we want all the errors, not just the first
-  }, (err, value) => {
+  joi.validate(config, schema, options, (err, value) => {
     // handle validation errors
     if (err)
       return logErrors(err)

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -11,9 +11,7 @@ const schema = joi.object({
   // optional number e.g. 3030
   port: joi.number(),
   // DEPRECATED optional number for page id or string for page name
-  frontPage: joi.any().forbidden().error(
-    new Error('frontPage has been deprecated in favour of custom routes, read more at tapestry-wp.js.org')
-  ),
+  frontPage: joi.any().forbidden(),
   // optional object containing React components
   components: joi.object().keys({
     Category: joi.func(),

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -4,14 +4,16 @@ import { logErrorObject } from './logger'
 
 // define valid config schema
 const schema = joi.object({
+  // DEPRECATED optional number for page id or string for page name
+  frontPage: joi.any().forbidden(),
+  // DEPRECATED optional loaders exporting a fetch request
+  loaders: joi.any().forbidden(),
   // required url
   siteUrl: joi.string().uri().required(),
   // optional string e.g. 'localhost', '0.0.0.0'
   host: joi.string(),
   // optional number e.g. 3030
   port: joi.number(),
-  // DEPRECATED optional number for page id or string for page name
-  frontPage: joi.any().forbidden(),
   // optional object containing React components
   components: joi.object().keys({
     Category: joi.func(),
@@ -30,13 +32,6 @@ const schema = joi.object({
       endpoint: joi.alternatives().try(joi.string(), joi.func())
     })
   ),
-  // optional loaders exporting a fetch request
-  loaders: joi.object().keys({
-    Category: joi.func(),
-    FrontPage: joi.func(),
-    Page: joi.func(),
-    Post: joi.func()
-  }),
   // optional array of proxy paths
   proxyPaths: joi.array().items(joi.string()),
   // optional object of redirects


### PR DESCRIPTION
Removed `loaders` and `frontPage` from `tapestry.config.js`. `joi` can't return custom error messages without overriding all other error messages. e.g. `joi.string().error('This is a custom error')` will _only_ return this error regardless of other errors in the object.

Replaced `logErrorObject` with `errorMessage` as we're only returning a string from `joi`

Fixes #114 #113 #60 