### PR TITLE
Rename error component

### DIFF
--- a/src/server/render/index.js
+++ b/src/server/render/index.js
@@ -17,8 +17,8 @@ export const renderHtml = ({
   assets
 }) => {
 
-  const Error = has(loadContext, 'loadContext.components.Error') ?
-    loadContext.components.Error :
+  const CustomError = has(loadContext, 'loadContext.components.CustomError') ?
+    loadContext.components.CustomError :
     MissingView
   // get html from props
   const data = {
@@ -29,7 +29,7 @@ export const renderHtml = ({
             {...renderProps}
             {...asyncProps}
             loadContext={loadContext} /> :
-          <Error />
+          <CustomError />
       )
     ),
     head: Helmet.rewind(),

--- a/src/shared/default-routes.js
+++ b/src/shared/default-routes.js
@@ -1,6 +1,6 @@
 // array of routes supplied with Tapestry
 export default ({
-  FrontPage, Post, Page, Category, Error
+  FrontPage, Post, Page, Category, CustomError
 }) => [{
   path: '/',
   component: FrontPage,
@@ -19,5 +19,5 @@ export default ({
   endpoint: params => `posts?slug=${params.postname}&_embed`
 }, {
   path: '*',
-  component: Error
+  component: CustomError
 }]

--- a/src/utilities/logger.js
+++ b/src/utilities/logger.js
@@ -33,4 +33,3 @@ export const logErrorObject = (errorObject, quit = true) => {
   errorMessage(errorObject.message)
   logObject(errorObject, quit)
 }
-

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -15,7 +15,7 @@ const schema = joi.object({
   // optional object containing React components
   components: joi.object().keys({
     Category: joi.func(),
-    Error: joi.func(),
+    CustomError: joi.func(),
     FrontPage: joi.func(),
     Page: joi.func(),
     Post: joi.func()

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -14,6 +14,7 @@ const schema = joi.object({
   frontPage: [joi.number(), joi.string()],
   // optional object containing React components
   components: joi.object().keys({
+    Error: joi.any().forbidden(), // DEPRECATED component
     Category: joi.func(),
     CustomError: joi.func(),
     FrontPage: joi.func(),

--- a/test/tests/component.test.js
+++ b/test/tests/component.test.js
@@ -36,6 +36,14 @@ describe('Components', () => {
       })
   })
 
+  it('CustomError will be rendered if declared', (done) => {
+    request
+      .get(`${tapestry.server.info.uri}/route/not/matched/in/any/way`, (err, res, body) => {
+        expect(body).to.contain('This is an error page')
+        done()
+      })
+  })
+
   it('Helmet <head> is rendered', (done) => {
     request
       .get(`${tapestry.server.info.uri}/2017/01/01/slug`, (err, res, body) => {


### PR DESCRIPTION
#### What have you done
Renamed the `Error` component to `CustomError` to avoid using a reserved term, happy to hear suggestions for another name.

#### Testing carried out to prevent breaking changes
Added a simple test to see if the `CustomError` component is being called on un-matched route.

Fixes #112 