### PR TITLE
Handle deprecated dependency warnings

### DIFF
--- a/bootstrap/components/page.js
+++ b/bootstrap/components/page.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import ObjectInspector from 'react-object-inspector'
 
 const Page = props =>

--- a/bootstrap/components/post.js
+++ b/bootstrap/components/post.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import ObjectInspector from 'react-object-inspector'
 
 const Post = props =>

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lru-cache": "^4.0.2",
     "mitt": "^1.1.0",
     "pretty-bytes": "^4.0.2",
+    "prop-types": "^15.5.7",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-helmet": "^5.0.3",

--- a/src/server/render/default-html.js
+++ b/src/server/render/default-html.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import has from 'lodash/has'
 import './default-style'
 

--- a/src/shared/fetch-data.js
+++ b/src/shared/fetch-data.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import AsyncProps from 'async-props'
 import has from 'lodash/has'
 import toArray from 'lodash/toArray'

--- a/src/shared/progress-indicator.js
+++ b/src/shared/progress-indicator.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { css } from 'glamor'
 
 const style = ({ percent, complete }) => css({

--- a/src/webpack/server.config.js
+++ b/src/webpack/server.config.js
@@ -3,6 +3,11 @@ const webpack = require('webpack')
 const nodeExternals = require('webpack-node-externals')
 const shared = require('./shared')
 
+// temp fix for webpack loader-utils deprecated message
+// waiting on babel-loader 7.0
+// https://github.com/webpack/loader-utils/issues/56
+process.noDeprecation = true
+
 // module.exports to enable CLI usage
 module.exports = ({ cwd, env }) => {
   // expose environment to user


### PR DESCRIPTION
#### What have you done
Replaced React `PropTypes` with `prop-types` package as recommended by FB, temporarily silencing `webpack` `loader-utils` deprecation warning.

#### Why have you done it
This was an attempt at removing all 5 deprecation warnings when booting tapestry, although I don't think we can do much about most of them.
* React warnings are coming from `async-props`, which I assume won't ever be fixed (a year since the last update)
* The `webpack` warning is a `babel-loader` issue, we're waiting on the `7.0.0` release to fix this
* `glamor` version 3 is still in beta so we can't remove these warnings until we upgrade