### PR TITLE
Simplified data normalisation

### DIFF
--- a/src/shared/fetch-data.js
+++ b/src/shared/fetch-data.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import AsyncProps from 'async-props'
 import has from 'lodash/has'
-import toArray from 'lodash/toArray'
+import isArray from 'lodash/isArray'
 import isEmpty from 'lodash/isEmpty'
 import { generate as uid } from 'shortid'
 import fetchRouteData from './fetch-route-data'
@@ -26,14 +26,15 @@ const fetchData = (TopLevelComponent, endpoint) => {
     }
 
     render() {
-      // check data exists and isnt a server errored response
-      if (!this.props.data || isEmpty(this.props.data) || has(this.props.data, 'data.status'))  {
+      // to avoid React mangling the array to {'0':{},'1':{}}
+      // pass through as 'posts'
+      const response = this.props.data
+      const data = isArray(response) ?
+        { posts: response } :
+        response
+      // check data exists and isn't a server errored response
+      if (!response || isEmpty(response) || has(response, 'data.status'))  {
         return <MissingView />
-      }
-      const resp = this.props.data
-      let data = ('0' in resp) || resp instanceof Array ? { posts: toArray(resp) } : resp
-      if (data.posts && data.posts.length == 1)  {
-        data = data.posts[0]
       }
       // otherwise return the actual component
       return (


### PR DESCRIPTION
The weird array like object syntax was appearing because we spread the array on the `TopLevelComponent`, React was converting it to an object.

Future talk, we should probably re-name this component and split out the data normalisation bit, perhaps the key `posts` should be dynamic based on the API endpoint, e.g. `tags`, `users`, `categories`.

Fixes #127 