### PR TITLE
escape slashes to prevent </script> in JSON in __ASYNC_PROPS__

### DIFF
--- a/src/server/render/default-html.js
+++ b/src/server/render/default-html.js
@@ -21,7 +21,26 @@ const defaultHtml = ({ markup, head, asyncProps, assets = {} }) => {
       </head>
       <body>
         <div id="root" dangerouslySetInnerHTML={{ __html: markup.html }} />
-        { hasProps && <script dangerouslySetInnerHTML={{ __html: `window.__ASYNC_PROPS__ = ${JSON.stringify(asyncProps.propsArray)}` }} /> }
+        {
+          hasProps &&
+            <script
+              type="text/javascript"
+              dangerouslySetInnerHTML={{
+                __html: `window.__ASYNC_PROPS__ = ${
+                  // Add a stringify template helper for outputting JSON with forward
+                  // slashes escaped to prevent '</script>' tag output in JSON within
+                  // script tags. See http://stackoverflow.com/questions/66837/when-is-a-cdata-section-necessary-within-a-script-tag/1450633#1450633
+                  JSON.stringify(asyncProps.propsArray)
+                    .replace(/\//g, '\\/')
+                    // Escape u2028 and u2029
+                    // http://timelessrepo.com/json-isnt-a-javascript-subset
+                    // https://github.com/mapbox/tilestream-pro/issues/1638
+                    .replace(/\u2028/g, "\\u2028")
+                    .replace(/\u2029/g, "\\u2029")
+                }`
+              }}
+            />
+        }
       </body>
     </html>
   )

--- a/test/tests/document.test.js
+++ b/test/tests/document.test.js
@@ -27,10 +27,15 @@ describe('HTML document', () => {
     tapestry.server.stop()
   })
 
-  it('Data is correctly loaded on page', (done) => {
+  it('Data is correctly loaded on page, escapes <script> tags', (done) => {
     request
       .get(`${tapestry.server.info.uri}/sample-page`, (err, res, body) => {
-        expect(body).to.contain(`window.__ASYNC_PROPS__ = [{"data":${JSON.stringify(pageData)}}]`)
+        expect(body).to.contain(`window.__ASYNC_PROPS__ = [{"data":${
+          JSON.stringify(pageData)
+            .replace(/\//g, '\\/')
+            .replace(/\u2028/g, "\\u2028")
+            .replace(/\u2029/g, "\\u2029")
+        }}]`)
         done()
       })
   })

--- a/test/tests/routing.test.js
+++ b/test/tests/routing.test.js
@@ -62,7 +62,12 @@ describe('Custom routes', () => {
   it('Dynamic route matches, queries custom endpoint', (done) => {
     request
       .get(`${tapestry.server.info.uri}/custom-endpoint/hi`, (err, res, body) => {
-        expect(body).to.contain(`window.__ASYNC_PROPS__ = [{"data":${JSON.stringify(pageData)}}]`)
+        expect(body).to.contain(`window.__ASYNC_PROPS__ = [{"data":${
+          JSON.stringify(pageData)
+            .replace(/\//g, '\\/')
+            .replace(/\u2028/g, "\\u2028")
+            .replace(/\u2029/g, "\\u2029")
+        }}]`)
         done()
       })
   })


### PR DESCRIPTION
#### What have you done
I have changed the `JSON.stringify` call in `default-html.js` to include `.replace` calls to escape any HTML tags. This approach is taken from: https://github.com/mapbox/safer-stringify

#### Why have you done it
This was causing any embedded `<script>` tags to be parsed by the browser as tags and not strings – meaning the `<script>` for the `window.__ASYNC_PROPS__` was closed by any `</script>` in the JSON string.

#### Testing carried out to prevent breaking changes
Updated tests