### PR TITLE
Update <AsyncPropsWrapper /> to only re-render when new data received

### DIFF
--- a/src/shared/fetch-data.js
+++ b/src/shared/fetch-data.js
@@ -22,18 +22,25 @@ const fetchData = (TopLevelComponent, route) => {
       return fetchRouteData({ loadFrom, loadContext, cb })
     }
 
-    componentWillReceiveProps() {
-      this.forceUpdate()
+    shouldComponentUpdate(nextProps) {
+      return this.props.data !== nextProps.data
     }
+
+    componentDidUpdate() {
+      this.handleViewUpdate()
+    }
+
     componentDidMount() {
-      // check if rendering in client
-      if (typeof window !== 'undefined') {
-        // reset scroll position
-        window.scrollTo(0, 0)
-        // run project callback
-        // wrapped in setTimeout to clear call stack (blocks progress indicator)
-        if (typeof this.props.route.config.onPageUpdate === 'function')
-          setTimeout(this.props.route.config.onPageUpdate, 0)
+      this.handleViewUpdate()
+    }
+
+    handleViewUpdate() {
+      const { onPageUpdate } = this.props.route.config
+      // reset scroll position
+      window.scrollTo(0, 0)
+      // wrapped in setTimeout to clear call stack (blocks progress indicator)
+      if (typeof onPageUpdate === 'function') {
+        setTimeout(onPageUpdate, 0)
       }
     }
 


### PR DESCRIPTION
#### What have you done
I have fixed an issue where `<AsyncPropsWrapper />` was re-rendering it's children when it's data didn't change.

This has been achieved by adding a check in `shouldComponentUpdate()`, and removing the `forceUpdate()` call in `componentWillReceiveProps()`.

I have also moved the `scrollTop()` and `onPageUpdate()` calls inside `componentDidMount()` and `componentDidUpdate()`, to ensure we are at the top of the new page and the `onPageUpdate` is called on initial and subsequent view renders.

#### Why have you done it
We were having unnecessary re-renders of the entire component tree on client-side navigation, before the next view had been rendered.