### PR TITLE
Winston logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,9 @@
     "source-map-support": "^0.4.14",
     "stats-webpack-plugin": "^0.6.0",
     "validator.js": "^2.0.3",
-    "webpack": "^2.3.3",
-    "webpack-node-externals": "^1.5.4"
+    "webpack": "^2.2.1",
+    "webpack-node-externals": "^1.5.4",
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -1,7 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import CacheManager from '../utilities/cache-manager'
 import { errorObject } from '../utilities/logger'
-
 import winston from 'winston'
 
 export default ({ server, config }) => {

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -2,6 +2,8 @@ import fetch from 'isomorphic-fetch'
 import CacheManager from '../utilities/cache-manager'
 import { errorObject } from '../utilities/logger'
 
+import winston from 'winston'
+
 export default ({ server, config }) => {
 
   // Create a new cache | 100 requests only, expire after 2 minutes
@@ -9,6 +11,7 @@ export default ({ server, config }) => {
 
   // Allow purge of individual URL
   server.on('purge-api-cache-by-key', (key) => {
+    winston.log('debug', `Server will purge api cache by key: ${key}`)
     cache.del(key)
   })
 
@@ -21,6 +24,7 @@ export default ({ server, config }) => {
       const cacheRecord = cache.get(remote)
       // If we find a response in the cache send it back
       if (cacheRecord) {
+        winston.log('debug', `Server loading API response from cache for ${remote}`)
         reply(cacheRecord.response)
       } else {
         fetch(remote)
@@ -36,6 +40,7 @@ export default ({ server, config }) => {
             cache.set(remote, {
               response: resp
             })
+            winston.log('debug', `Server returned a fresh API response over HTTP for ${remote}`)
             reply(resp)
           })
           .catch(error => errorObject(error))

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -14,7 +14,7 @@ export default ({ server, config, assets }) => {
   const cache = CacheManager.createCache('html')
  // Allow purge of individual URL
   server.on('purge-html-cache-by-key', (key) => {
-    winston.loggers('debug', `Server will purge html cache by key: ${key}`)
+    winston.log('debug', `Server will purge html cache by key: ${key}`)
     cache.del(key)
   })
 

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -1,6 +1,7 @@
 import { match } from 'react-router'
 import { loadPropsOnServer } from 'async-props'
 import has from 'lodash/has'
+import winston from 'winston'
 
 import RouteWrapper from '../shared/route-wrapper'
 import { renderHtml } from './render'
@@ -13,6 +14,7 @@ export default ({ server, config, assets }) => {
   const cache = CacheManager.createCache('html')
  // Allow purge of individual URL
   server.on('purge-html-cache-by-key', (key) => {
+    winston.loggers('debug', `Server will purge html cache by key: ${key}`)
     cache.del(key)
   })
 
@@ -70,6 +72,7 @@ export default ({ server, config, assets }) => {
 
           // respond with HTML from cache if not undefined
           if (cachedHTML) {
+            winston.log('debug', `Server loading HTML from cache for ${request.url.path}`)
             reply(cachedHTML).code(status)
           } else {
             // No HTML found for this path, or cache expired
@@ -85,6 +88,7 @@ export default ({ server, config, assets }) => {
             // We can only get here if there's nothing cached for this URL path
             // Bung the HTML into the cache
             cache.set(request.url.path, html)
+            winston.log('debug', `Server rendered HTML from scratch for ${request.url.path}`)
             reply(html).code(status)
           }
         })

--- a/src/server/handle-purge.js
+++ b/src/server/handle-purge.js
@@ -1,4 +1,4 @@
-import { winston } from 'winston'
+import winston from 'winston'
 import { match } from 'react-router'
 import RouteWrapper from '../shared/route-wrapper'
 const purgePath = process.env.SECRET_PURGE_PATH || 'purge'

--- a/src/server/handle-purge.js
+++ b/src/server/handle-purge.js
@@ -1,3 +1,4 @@
+import { winston } from 'winston'
 import { match } from 'react-router'
 import RouteWrapper from '../shared/route-wrapper'
 const purgePath = process.env.SECRET_PURGE_PATH || 'purge'
@@ -13,6 +14,7 @@ export default ({ server, config }) => {
       if (typeof endpoint == 'function') {
         endpoint = endpoint(renderProps.params)
       }
+      winston.log('debug', `Purge request for endpoint ${endpoint}`)
       cb(endpoint)
     })
   }
@@ -22,9 +24,16 @@ export default ({ server, config }) => {
     path: `/${purgePath}/{path*}`,
     handler: (request, reply) => {
       calculateApiRoute(request.params.path, (apiRoute) => {
+
+        winston.log('debug', `Request: ${request.params.path} mapped to API: ${apiRoute}`)
         const remote = `${config.siteUrl}/wp-json/wp/v2/${apiRoute}`
+
+        winston.log('debug', `Emitting purge-html-cache-by-key for ${request.params.path}`)
         server.emit('purge-html-cache-by-key', `/${request.params.path}`)
+
+        winston.log('debug', `Emitting purge-api-cache-by-key for ${remote}`)
         server.emit('purge-api-cache-by-key', `${remote}`)
+
         reply({status: `Purged ${request.params.path}`}, 200)
       })
     }

--- a/src/server/handle-purge.js
+++ b/src/server/handle-purge.js
@@ -29,7 +29,7 @@ export default ({ server, config }) => {
         const remote = `${config.siteUrl}/wp-json/wp/v2/${apiRoute}`
 
         winston.log('debug', `Emitting purge-html-cache-by-key for ${request.params.path}`)
-        server.emit('purge-html-cache-by-key', `/${request.params.path}`)
+        server.emit('purge-html-cache-by-key', `${request.params.path}`)
 
         winston.log('debug', `Emitting purge-api-cache-by-key for ${remote}`)
         server.emit('purge-api-cache-by-key', `${remote}`)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,7 +3,7 @@ import h2o2 from 'h2o2'
 import Inert from 'inert'
 import idx from 'idx'
 import winston from 'winston'
-winston.level = process.env.LOG_LEVEL
+winston.level = process.env.LOG_LEVEL || 'info'
 
 import { success, errorObject } from '../utilities/logger'
 import handleStatic from './handle-static'

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -12,6 +12,10 @@ import handlePurge from './handle-purge'
 import handleRedirects from './handle-redirects'
 import CacheManager from '../utilities/cache-manager'
 
+import winston from 'winston'
+
+winston.level = process.env.LOG_LEVEL
+
 export default class Tapestry {
 
   constructor ({ config, assets = {} }, { silent } = {}) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,6 +2,8 @@ import { Server } from 'hapi'
 import h2o2 from 'h2o2'
 import Inert from 'inert'
 import idx from 'idx'
+import winston from 'winston'
+winston.level = process.env.LOG_LEVEL
 
 import { success, errorObject } from '../utilities/logger'
 import handleStatic from './handle-static'
@@ -11,10 +13,6 @@ import handleProxies from './handle-proxies'
 import handlePurge from './handle-purge'
 import handleRedirects from './handle-redirects'
 import CacheManager from '../utilities/cache-manager'
-
-import winston from 'winston'
-
-winston.level = process.env.LOG_LEVEL
 
 export default class Tapestry {
 


### PR DESCRIPTION
#### What have you done

Added the logging libary: https://github.com/winstonjs/winston

When you run tapestry or the tests, you can now define a `LOG_LEVEL` environment variable when you run the application, this is mapped to Winston's internal logging levels.

For example:

`LOG_LEVEL=debug npm test` will mean tapestry logs out all the statements with the log level... you guessed it: debug

`winston.log('debug', 'this is some stuff I only want to read if LOG_LEVEL=debug')`

#### Why have you done it
More logging = more bug fixing. I found a purge bug straight away!

#### Testing carried out to prevent breaking changes
All the tests are passing!

<img width="1259" alt="screen shot 2017-05-25 at 19 05 45" src="https://cloud.githubusercontent.com/assets/631670/26463740/3d3282a2-417d-11e7-82c2-4134d0b00fec.png">

