### PR TITLE
Enable webpack directory cache

### DIFF
--- a/src/webpack/shared.js
+++ b/src/webpack/shared.js
@@ -5,6 +5,7 @@ module.exports = (babelrc) => ({
     use: [{
       loader: 'babel-loader',
       options: babelrc || {
+        cacheDirectory: true,
         presets: [
           'es2015',
           'react'


### PR DESCRIPTION
#### What have you done
Enabled webpack's directory cache

#### Why have you done it
Saw this tweet: https://twitter.com/TheLarkInn/status/879315255851077632

#### Testing carried out to prevent breaking changes
Cuts 3.5 to 4 seconds off Webpack compile times on my personal machine.

_Attach screenshot if visual_
