### PR TITLE
Added normalisation method for cache keys, updated and added debug logs

### DIFF
--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import fetch from 'isomorphic-fetch'
-import CacheManager, { normalizePath } from '../utilities/cache-manager'
+import CacheManager, { stripLeadingTrailingSlashes } from '../utilities/cache-manager'
 import log from '../utilities/logger'
 
 let cacheManager = new CacheManager()
@@ -15,10 +15,10 @@ export default ({ server, config }) => {
     path: '/api/v1/{query*}',
     handler: (req, reply) => {
 
-      const base = `${normalizePath(config.siteUrl)}/wp-json/wp/v2`
+      const base = `${stripLeadingTrailingSlashes(config.siteUrl)}/wp-json/wp/v2`
       const path = `${req.params.query}${req.url.search}`
       const remote = `${base}/${path}`
-      const cacheKey = normalizePath(path)
+      const cacheKey = stripLeadingTrailingSlashes(path)
 
       // Look for a cached response - maybe undefined
       const cacheRecord = cache.get(cacheKey)

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -7,7 +7,7 @@ import chalk from 'chalk'
 import RouteWrapper from '../shared/route-wrapper'
 import { renderHtml } from './render'
 import log from '../utilities/logger'
-import CacheManager, { normalizePath } from '../utilities/cache-manager'
+import CacheManager, { stripLeadingTrailingSlashes } from '../utilities/cache-manager'
 let cacheManager = new CacheManager()
 
 export default ({ server, config, assets }) => {
@@ -62,7 +62,7 @@ export default ({ server, config, assets }) => {
 
           const failApi = has(asyncProps.propsArray[0], 'data.data.status')
           const failRoute = renderProps.routes[1].path === '*'
-          const cacheKey = normalizePath(request.url.path)
+          const cacheKey = stripLeadingTrailingSlashes(request.url.path)
 
           if (failApi || failRoute)
             status = 404

--- a/src/utilities/cache-manager.js
+++ b/src/utilities/cache-manager.js
@@ -5,6 +5,13 @@ import log from '../utilities/logger'
 let internalCaches = []
 let instance = null
 
+export const normalizePath = path => {
+  if (path !== '/') {
+    return path.replace(/^\/+|\/+$/g, '')
+  }
+  return path
+}
+
 export default class CacheManager {
 
 

--- a/src/utilities/cache-manager.js
+++ b/src/utilities/cache-manager.js
@@ -5,7 +5,7 @@ import log from '../utilities/logger'
 let internalCaches = []
 let instance = null
 
-export const normalizePath = path => {
+export const stripLeadingTrailingSlashes = path => {
   if (path !== '/') {
     return path.replace(/^\/+|\/+$/g, '')
   }


### PR DESCRIPTION
#### What have you done
Added a terrible piece of regex to normalise the cache keys. Applied to `siteUrl` in API handler as it was sometimes doubling up the first `/`.

Also added and updated a bunch of the debug logs to improve their usefulness.

#### Why have you done it
#206 

#### Testing carried out to prevent breaking changes
Added tests for setting cache items and retrieving them