### PR TITLE
!MERGE - Improve server security

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -64,7 +64,13 @@ export default class Tapestry {
     const host = idx(this.config, _ => _.options.host)
     const port = idx(this.config, _ => _.options.port)
     // create new Hapi server and register required plugins
-    const server = new Server()
+    const server = new Server({
+      connections: {
+        routes: {
+          security: true
+        }
+      }
+    })
     server.register([h2o2, Inert])
     server.connection({
       host: host || '0.0.0.0',


### PR DESCRIPTION
Switched on default security preference in Hapi, these options cover off a couple of issues including #218 #217 #216 

I noticed that it doesn't contain a Content Security Policy so I'm going to look at including it manually. _Unless_ we want to modify the headers through the `tapestry.config.js`?

https://hapijs.com/api#route-options