### PR TITLE
Temporarily removing the tapestry.log file as it was erroring on a fresh build

### DIFF
--- a/src/utilities/logger.js
+++ b/src/utilities/logger.js
@@ -1,8 +1,6 @@
 const chalk = require('chalk')
 const winston = require('winston')
-const path = require('path')
 
-const cwd = process.cwd()
 const tsFormat = () => (new Date()).toLocaleTimeString()
 
 const log = new (winston.Logger)({
@@ -11,10 +9,6 @@ const log = new (winston.Logger)({
       timestamp: tsFormat,
       colorize: true,
       prettyPrint: true
-    }),
-    new (winston.transports.File)({
-      filename: path.resolve(cwd, '.tapestry/tapestry-log.log'),
-      timestamp: tsFormat
     })
   ]
 })
@@ -28,4 +22,3 @@ module.exports.log = log
 module.exports.notify = (str) => {
   console.log(`${chalk.green('→')} ${chalk.white(str)}`) // eslint-disable-line
 }
-


### PR DESCRIPTION
`winston` errors out if it can't find the directory to store the log file, in this case `.tapestry/`. We should fix this and keep the log file, but for now to get `2.0.0-14` ready for production we need to remove it.