### PR TITLE
Fix/retain redirect querystring

### DIFF
--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -2,18 +2,20 @@ import fs from 'fs'
 import path from 'path'
 
 const setRedirects = (server, redirects ) => {
-  Object.keys(redirects).forEach(fromPath => {
-    server.route({
-      method: 'GET',
-      path: `${fromPath}`,
-      handler: (request, reply) => {
-        reply
-          .redirect(redirects[fromPath])
-          .permanent()
-          .rewritable(false)
-      }
+  Object
+    .keys(redirects)
+    .forEach(fromPath => {
+      server.route({
+        method: 'GET',
+        path: `${fromPath}`,
+        handler: (request, reply) => {
+          reply
+            .redirect(`${redirects[fromPath]}${request.url.search}`)
+            .permanent()
+            .rewritable(false)
+        }
+      })
     })
-  })
 }
 
 export default ({ server, config }) => {

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-const setRedirects = (server, redirects ) => {
+const setRedirects = (server, redirects) => {
   Object
     .keys(redirects)
     .forEach(fromPath => {

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -13,7 +13,8 @@ describe('Handling redirects', () => {
   let uri = null
   let config = {
     redirectPaths: {
-      '/redirect/from/this-path': '/page'
+      '/redirect/from/this-path': '/page',
+      '/redirect/with/query': '/page'
     },
     siteUrl: 'http://dummy.api',
     components: {
@@ -25,6 +26,7 @@ describe('Handling redirects', () => {
     // mock api response
     nock('http://dummy.api')
       .get('/wp-json/wp/v2/pages?slug=page&_embed')
+      .times(2)
       .reply(200, dataPage)
     // boot tapestry server
     tapestry = bootServer(config)
@@ -47,6 +49,14 @@ describe('Handling redirects', () => {
     request.get(`${uri}/redirect/from/this-path`, (err, res, body) => {
       expect(body).to.contain('Redirected component')
       expect(res.statusCode).to.equal(200)
+      done()
+    })
+  })
+
+  it('Redirect path contains querystring', (done) => {
+    const query = '?querystring=something'
+    request.get(`${uri}/redirect/with/query${query}`, (err, res, body) => {
+      expect(res.req.path).to.contain(`/page${query}`)
       done()
     })
   })


### PR DESCRIPTION
#### What have you done
Added `request.url.search` to the redirect path to retain the query string

#### Why have you done it
Because it was missing

#### Testing carried out to prevent breaking changes
Added test and tested locally