### PR TITLE
Added a year long cache for static script files

### DIFF
--- a/src/server/handle-static.js
+++ b/src/server/handle-static.js
@@ -1,6 +1,14 @@
 
 export default ({ server }) => {
 
+  const cacheConfig = {
+    // cache static assets for 1 year
+    privacy: 'public',
+    expiresIn: process.env.NODE_ENV === 'production' ?
+      31557600000 :
+      1
+  }
+
   // Default favicon redirect
   server.route({
     method: 'GET',
@@ -20,6 +28,9 @@ export default ({ server }) => {
     server.route({
       method: 'GET',
       path: `/${path}/{param*}`,
+      config: {
+        cache: path === '_scripts' && cacheConfig
+      },
       handler: {
         directory: {
           path: path


### PR DESCRIPTION
As far as I can tell Hapi doesn't support a cache expiry date, only a relative `expiresIn` value in milliseconds. https://hapijs.com/api#route-options

Fixes #223 