### PR TITLE
Added hapi-require-https to Hapi plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "glob-fs": "^0.1.6",
     "h2o2": "^5.4.0",
     "hapi": "~16.4.3",
+    "hapi-require-https": "^2.1.0",
     "http-status": "^1.0.1",
     "idx": "^1.5.0",
     "inert": "^4.2.0",

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -58,7 +58,9 @@ const schema = joi.object({
     // number e.g. 3030
     port: joi.number(),
     // theme color for progress bar
-    progressBarColor: joi.string()
+    progressBarColor: joi.string(),
+    // registers https Hapi plugin
+    forceHttps: joi.boolean()
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,6 +2479,10 @@ h2o2@^5.4.0:
     joi "9.X.X"
     wreck "9.X.X"
 
+hapi-require-https@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hapi-require-https/-/hapi-require-https-2.1.0.tgz#440e364cd42e979e02df05e91adfd9da03b4aa72"
+
 hapi@~16.4.3:
   version "16.4.3"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.4.3.tgz#be4daaf2dcdbee97957ce503061b09765078aa05"


### PR DESCRIPTION
Shifted registering the plugins until after `connection` as per Hapis [docs](https://hapijs.com/api#serverregisterplugins-options-callback), also logging any plugin errors at registration time.

Tested locally and it redirects to `https`, `https://0.0.0.0:3030` doesn't work but I'm assuming we'll have no issue.

Fixes #210 