### PR TITLE
Fix for 404 bug

### DIFF
--- a/src/shared/handle-api-response.js
+++ b/src/shared/handle-api-response.js
@@ -19,7 +19,16 @@ export default (response, route) => {
       !idx(routeConfig, _ => _[0].options.allowEmptyResponse)
     )
   ) {
-    const status = idx(response, _ => _.data.status) || HTTPStatus.NOT_FOUND
+    // Assign status
+    let status = idx(response, _ => _.data.status) || HTTPStatus.NOT_FOUND
+
+    // Check for static routes with no endpoint
+    const routeExistsWithNoEndpoint = idx(routeConfig, _ => _[0].path) &&
+      !idx(routeConfig, _ => _[0].endpoint)
+
+    // If the route is registered but has no endpoint, assume 200
+    status = routeExistsWithNoEndpoint ? HTTPStatus.OK : status
+
     return {
       code: status,
       message: HTTPStatus[status]


### PR DESCRIPTION
#### What have you done
Test and fix for statically registered routes being return with 404 status codes. Try any Tapestry project on the latest version that has statically registered routes. You'll see in dev tools that the `document` is being returned with a 404 status.

#### Why have you done it
404 response codes are bad when we are responding correctly.

#### Testing carried out to prevent breaking changes
Includes a test.
