### PR TITLE
Feature/dynamic redirects

### DIFF
--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -30,6 +30,7 @@ export default ({ server, config }) => {
     const redirectsFromFile = JSON.parse(fs.readFileSync(redirectsFile, 'utf8'))
     setRedirects(server, redirectsFromFile)
   }
+  // Set redirects from a dynamic endpoint
   if (config.redirectsEndpoint) {
     fetch(config.redirectsEndpoint)
       .then(resp => resp.json())

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -34,7 +34,18 @@ export default ({ server, config }) => {
   // Set redirects from a dynamic endpoint
   if (config.redirectsEndpoint) {
     fetch(config.redirectsEndpoint)
-      .then(resp => resp.json())
+      .then(resp => {
+        if (resp.status === 200) {
+          return resp.json()
+        } else {
+          // Mimic fetch error API
+          throw {
+            name: 'FetchError',
+            message: `Non 200 response ${resp.status}`,
+            type: 'http-error'
+          }
+        }
+      })
       .then(data => {
         setRedirects(server, data)
       })

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import fetch from 'isomorphic-fetch'
 
 const setRedirects = (server, redirects) => {
   Object
@@ -28,5 +29,12 @@ export default ({ server, config }) => {
   if (fs.existsSync(redirectsFile)) {
     const redirectsFromFile = JSON.parse(fs.readFileSync(redirectsFile, 'utf8'))
     setRedirects(server, redirectsFromFile)
+  }
+  if (config.redirectsEndpoint) {
+    fetch(config.redirectsEndpoint)
+      .then(resp => resp.json())
+      .then(data => {
+        setRedirects(server, data)
+      })
   }
 }

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import fetch from 'isomorphic-fetch'
+import { log } from '../utilities/logger'
 
 const setRedirects = (server, redirects) => {
   Object
@@ -37,5 +38,6 @@ export default ({ server, config }) => {
       .then(data => {
         setRedirects(server, data)
       })
+      .catch(err => log.error(`Redirects Endpoint FAILED: ${JSON.stringify(err)}`))
   }
 }

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -47,7 +47,7 @@ const schema = joi.object({
   ),
   // optional array of proxy paths e.g. ['path', 'another/path']
   proxyPaths: joi.array().items(joi.string()),
-  // optional object of redirects e.g. { 'path': 'to-redirct' }
+  // optional object of redirects e.g. { 'path': 'to-redirect' }
   redirectPaths: joi.object().pattern(/.*/, joi.string()),
   // optional endpoint to load redirects.json from
   redirectsEndpoint: joi.string().uri(),

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -47,8 +47,10 @@ const schema = joi.object({
   ),
   // optional array of proxy paths e.g. ['path', 'another/path']
   proxyPaths: joi.array().items(joi.string()),
-  // optional object of redirects e.g. { 'path': 'to-redirect' }
+  // optional object of redirects e.g. { 'path': 'to-redirct' }
   redirectPaths: joi.object().pattern(/.*/, joi.string()),
+  // optional endpoint to load redirects.json from
+  redirectsEndpoint: joi.string().uri(),
   // optional function run when routing on the client
   onPageUpdate: joi.func(),
   // misc options

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -23,6 +23,7 @@ describe('Handling redirects', () => {
       '/redirect/from/this-path': '/page',
       '/redirect/with/query': '/page'
     },
+    redirectsEndpoint: 'http://dummy.api/web/app/uploads/redirects.json',
     siteUrl: 'http://dummy.api'
   }
 
@@ -33,6 +34,11 @@ describe('Handling redirects', () => {
       JSON.stringify({'/redirect/from/file': '/page' }), // create dummy file
       'utf8' // encoding
     )
+
+     nock('http://dummy.api')
+      .get('/web/app/uploads/redirects.json')
+      .times(1)
+      .reply(200, {'/redirect/from/endpoint': '/page'})
 
     // boot tapestry server
     tapestry = bootServer(config)
@@ -72,6 +78,14 @@ describe('Handling redirects', () => {
 
   it('Redirect path loaded from `redirects.json` file', (done) => {
     request.get(`${uri}/redirect/from/file`, (err, res, body) => {
+      expect(body).to.contain('Redirected component')
+      expect(res.statusCode).to.equal(200)
+      done()
+    })
+  })
+
+   it('Redirect path loaded from redirect endpoint', (done) => {
+    request.get(`${uri}/redirect/from/endpoint`, (err, res, body) => {
       expect(body).to.contain('Redirected component')
       expect(res.statusCode).to.equal(200)
       done()

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -84,7 +84,7 @@ describe('Handling redirects', () => {
     })
   })
 
-   it('Redirect path loaded from redirect endpoint', (done) => {
+   it('Redirect path loaded from redirects endpoint', (done) => {
     request.get(`${uri}/redirect/from/endpoint`, (err, res, body) => {
       expect(body).to.contain('Redirected component')
       expect(res.statusCode).to.equal(200)

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -126,7 +126,6 @@ describe('Handling endpoint redirects', () => {
 
     nock('http://dummy.api')
       .get('/web/app/uploads/redirects.json')
-      .times(1)
       .reply(404)
 
     // boot tapestry server
@@ -146,7 +145,6 @@ describe('Handling endpoint redirects', () => {
 
     nock('http://dummy.api')
       .get('/web/app/uploads/redirects.json')
-      .times(1)
       .reply(200, 'Error: <p>Something went wrong')
 
     // boot tapestry server


### PR DESCRIPTION
#### What have you done
Implemented some tests and a very basic implementation for setting redirects from a remote endpoint

#### Why have you done it
We need to be able to consume redirects from the CMS. The rational being that at least we can update redirects speedily by restarting the dynos on heroku.

#### Testing carried out to prevent breaking changes
There's a test
