### PR TITLE
Feature/allow rewriteable redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 2.0.0-18
+* Pinned Glamor version exactly to prevent regression around `attr()`
+
 #### 2.0.0-17
 * Upgraded to webpack 3.4.0
 * Rewrote cache logs, updated some `debug` calls to `silly`

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -14,7 +14,7 @@ const setRedirects = (server, redirects) => {
           reply
             .redirect(`${redirects[fromPath]}${request.url.search}`)
             .permanent()
-            .rewritable(false)
+            .rewritable(true)
         }
       })
     })

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -53,9 +53,9 @@ describe('Handling redirects', () => {
     tapestry.server.stop()
   })
 
-  it('Redirect returns 308 status', (done) => {
+  it('Redirect returns 301 status', (done) => {
     tapestry.server.inject(`${uri}/redirect/from/this-path`, (res) => {
-      expect(res.statusCode).to.equal(308)
+      expect(res.statusCode).to.equal(301)
       done()
     })
   })


### PR DESCRIPTION
#### What have you done
Allow HAPI to rewrite the HTTP verbs of redirect requests. 301 permanent over 308

#### Why have you done it
IE doesn't support 308 redirects

#### Testing carried out to prevent breaking changes
`redirects.test.js`

_Attach screenshot if visual_
