### PR TITLE
Use 301 status for redirects for IE 10/11 compatibility

### DIFF
--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -14,7 +14,7 @@ const setRedirects = (server, redirects) => {
           reply
             .redirect(`${redirects[fromPath]}${request.url.search}`)
             .permanent()
-            .rewritable(false)
+            .rewritable(true)
         }
       })
     })

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -53,9 +53,9 @@ describe('Handling redirects', () => {
     tapestry.server.stop()
   })
 
-  it('Redirect returns 308 status', (done) => {
+  it('Redirect returns 301 status', (done) => {
     tapestry.server.inject(`${uri}/redirect/from/this-path`, (res) => {
-      expect(res.statusCode).to.equal(308)
+      expect(res.statusCode).to.equal(301)
       done()
     })
   })


### PR DESCRIPTION
#### What have you done
Allow underlying Hapi server to rewrite HTTP verbs during redirect requests:

`308` will become `301`

#### Why have you done it

IE10/IE11 do not support 308 redirects

#### Testing carried out to prevent breaking changes
Updated the test in `redirects.test.js`

_Attach screenshot if visual_
