### PR TITLE
Handle preview endpoints and don't set a cache header

### DIFF
--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -16,6 +16,7 @@ export default ({ server, config, assets }) => {
   // Create a new cache
   const cache = cacheManager.createCache('html')
 
+
   server.route({
     config: {
       cache: {
@@ -26,7 +27,7 @@ export default ({ server, config, assets }) => {
     method: 'GET',
     path: '/{path*}',
     handler: (request, reply) => {
-
+      const isPreview = idx(request, _ => _.query.tapestry_hash)
       match({
         routes: RouteWrapper(config),
         location: request.url.path
@@ -97,11 +98,14 @@ export default ({ server, config, assets }) => {
 
             // 200 with rendered HTML
             log.debug(`HTML rendered from scratch for ${chalk.green(cacheKey)}`)
-            reply(html).code(status)
+            if (isPreview) {
+              reply(html).header('cache-control', 'no-cache')
+            } else {
+              reply(html).code(status)
+            }
 
             // We can only get here if there's nothing cached for this URL path
             // Bung the HTML into the cache, if not a preview link
-            const isPreview = idx(renderProps, _ => _.location.query.tapestry_hash)
 
             if (!isPreview) {
               log.debug(`Cache set ${chalk.green(cacheKey)} in html`)

--- a/test/tests/response.test.js
+++ b/test/tests/response.test.js
@@ -17,7 +17,12 @@ describe('Handling server responses', () => {
       path: '/',
       endpoint: 'posts?_embed',
       component: () => <p>Hello</p>
-    }, {
+    },
+    {
+      path: '/:cat/:subcat/:id',
+      component: () => <p>Hello</p>
+    },
+    {
       path: '/404-response',
       endpoint: 'pages?slug=404-response',
       component: () => <p>Hello</p>
@@ -48,6 +53,9 @@ describe('Handling server responses', () => {
   before(done => {
     // mock api response
     nock('http://dummy.api')
+      .get('/wp-json/wp/v2/posts/571')
+      .times(1)
+      .reply(200, dataPages.data)
       .get('/wp-json/wp/v2/pages')
       .times(1)
       .reply(200, dataPages.data)
@@ -88,6 +96,14 @@ describe('Handling server responses', () => {
     request.get(uri, (err, res) => {
       expect(res.headers['content-type']).to.equal('text/html; charset=utf-8')
       expect(res.headers['cache-control']).to.equal('max-age=60, must-revalidate, public')
+      done()
+    })
+  })
+
+  it('Preview routes send no-cache headers', (done) => {
+    request.get(`${uri}/foo/bar/571?tapestry_hash=somesortofhash&p=571`, (err, res) => {
+      expect(res.headers['content-type']).to.equal('text/html; charset=utf-8')
+      expect(res.headers['cache-control']).to.equal('no-cache')
       done()
     })
   })


### PR DESCRIPTION
#### What have you done
Fix https://github.com/shortlist-digital/tapestry-wp/issues/249

#### Why have you done it
Don't want to cache previews on the CDN

#### Testing carried out to prevent breaking changes
New tests written

_Attach screenshot if visual_
