### PR TITLE
Add test and fix caching bug, where query params were cached

### DIFF
--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -75,7 +75,7 @@ export default ({ server, config, assets }) => {
             response.code :
             HTTPStatus.OK
 
-          const cacheKey = stripLeadingTrailingSlashes(request.url.path)
+          const cacheKey = stripLeadingTrailingSlashes(request.url.pathname)
 
           // Find HTML based on path - might be undefined
           const cachedHTML = cache.get(cacheKey)

--- a/test/tests/cache.test.js
+++ b/test/tests/cache.test.js
@@ -161,6 +161,7 @@ describe('Handling cache set/get', () => {
     request.get(`${uri}/2017/12/01/query-test?utm_source=stop-it`, (err, res, body) => {
       const cacheHtml = cacheManager.getCache('html')
       expect(cacheHtml.keys()).to.include('2017/12/01/query-test')
+      expect(cacheHtml.keys()).to.not.include('2017/12/01/query-test?utm_source=stop-it')
       done()
     })
   })

--- a/test/tests/cache.test.js
+++ b/test/tests/cache.test.js
@@ -131,6 +131,8 @@ describe('Handling cache set/get', () => {
       .reply(200, dataPosts.data)
       .get('/wp-json/wp/v2/posts?slug=test&_embed')
       .reply(200, dataPost)
+      .get('/wp-json/wp/v2/posts?slug=query-test&_embed')
+      .reply(200, dataPost)
     // boot tapestry server
     tapestry = bootServer(config, { __DEV__: false })
     tapestry.server.on('start', () => {
@@ -151,6 +153,14 @@ describe('Handling cache set/get', () => {
       const cacheHtml = cacheManager.getCache('html')
       expect(cacheApi.keys()).to.include('posts?_embed')
       expect(cacheHtml.keys()).to.include('/')
+      done()
+    })
+  })
+
+  it('Sets API/HTML cache items without query string', done => {
+    request.get(`${uri}/2017/12/01/query-test?utm_source=stop-it`, (err, res, body) => {
+      const cacheHtml = cacheManager.getCache('html')
+      expect(cacheHtml.keys()).to.include('2017/12/01/query-test')
       done()
     })
   })


### PR DESCRIPTION
#### What have you done
HTML cache no ignores query parameters

#### Why have you done it
Lots of URLs include Dotmailer or Google tracking with unique IDs. They're entering the cache as unique entrants which was essentially rendering the HTML cache redundant.

#### Testing carried out to prevent breaking changes
New test aded. All tests passed.

_Attach screenshot if visual_
