### PR TITLE
Rewrite redirects to functionality to execute after a server-side 404 …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-wp",
-  "version": "2.0.0-23",
+  "version": "2.0.0-24",
   "description": "Wordpress API Universal React Renderer",
   "main": "./src/index.js",
   "files": [

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -9,7 +9,7 @@ const setRedirects = (server, redirects) => {
     if (
       (status === 404)
       && redirects
-      && (request.url.pathname in redirects)
+      && (typeof redirects[request.url.pathname] !== "undefined")
     ) {
       return reply
         .redirect(`${redirects[request.url.pathname]}${request.url.search}`)

--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -7,7 +7,7 @@ const setRedirects = (server, redirects) => {
   server.ext('onPostHandler', (request, reply) => {
     const status = reply.request.response.statusCode
     if (
-      (status == 404)
+      (status === 404)
       && redirects
       && (request.url.pathname in redirects)
     ) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -43,6 +43,7 @@ export default class Tapestry {
       config: this.config,
       assets
     }
+
     handleRedirects(data)
     handleStatic(data)
     handlePurge(data)

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -8,6 +8,7 @@ import nock from 'nock'
 
 import { bootServer } from '../utils'
 import dataPage from '../mocks/page.json'
+import dataRedirects from '../mocks/redirects.json'
 
 describe('Handling redirects', () => {
 
@@ -16,7 +17,7 @@ describe('Handling redirects', () => {
   let uri = null
   let config = {
     routes: [{
-      path: 'page',
+      path: '/page',
       component: () => <p>Redirected component</p>
     }],
     redirectPaths: {
@@ -31,7 +32,7 @@ describe('Handling redirects', () => {
     // create redirects file sync to prevent race condition
     fs.writeFileSync(
       redirectsFilePath, // file name
-      JSON.stringify({'/redirect/from/file': '/page' }), // create dummy file
+      JSON.stringify(dataRedirects), // create dummy file
       'utf8' // encoding
     )
 
@@ -77,7 +78,7 @@ describe('Handling redirects', () => {
   })
 
   it('Redirect path loaded from `redirects.json` file', (done) => {
-    request.get(`${uri}/redirect/from/file`, (err, res, body) => {
+    request.get(`${uri}/redirect/from/this`, (err, res, body) => {
       expect(body).to.contain('Redirected component')
       expect(res.statusCode).to.equal(200)
       done()

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -108,14 +108,14 @@ describe('Handling endpoint redirects', () => {
     nock('http://dummy.api')
       .get('/web/app/uploads/redirects.json')
       .times(1)
-      .reply(200, {'/redirect/from/endpoint': '/page'})
+      .reply(200, dataRedirects)
 
     // boot tapestry server
     tapestry = bootServer(config)
 
     tapestry.server.on('start', () => {
       uri = tapestry.server.info.uri
-      request.get(`${uri}/redirect/from/endpoint`, (err, res, body) => {
+      request.get(`${uri}/redirect/from/this`, (err, res, body) => {
         expect(body).to.contain('Redirected component')
         expect(res.statusCode).to.equal(200)
         done()


### PR DESCRIPTION
…only. No handlers set any more (they\'re expensive)

#### What have you done
I've rewritten how redirects work. They no longer set a computationally expensive handler per redirect using Hapi.

Instead, after the handler has run, we check if Hapi is _about_ to respond with a 404. Then it's last chance saloon, and we check if the origin request path is in our redirects object (in-memory), if we find it, then we hijack the reply and send our own redirect instead of the old 404

#### Why have you done it
It was taking 30 minutes to set 30k handlers

#### Testing carried out to prevent breaking changes
All tests passing, and the `redirects.json` handlers, both file and remote endpoint tests, now use a 50k line redirects file.

I've also tried this on a large project with 25k redirects, and it boots up instantly.

## Bad things:

### Making useless requests:

The only problem is we fire off and cache a lot of HTML and API responses, mostly the 404 page, so we could potentially do this *before* any routing/requesting/rendering happens using the `onPreResponse` handler instead of `onPostHandler`

### Doesn't fix client side nav redirects

We could do something like like ask the 404 page component to hard refresh itself when you client side nav to it (`componentDidMount`). That'd then check the server for a redirect... Maybe leave that to user land.

### Something else... Memory

Something else.... the first thing I came here to write... but have now forgotten.

Ah yes! What are the ramifications of loading large redirects files into Memory? 50k redirects = about 4.5 mb of JSON.