### PR TITLE
Wordpress.com API Integration

### DIFF
--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -7,7 +7,9 @@ let cacheManager = new CacheManager()
 
 const buildBaseUrl = config => {
   if (config.options && config.options.wordpressDotComHosting) {
-    const siteUrl = stripLeadingTrailingSlashes(config.siteUrl)
+    // Remove protocol
+    const noProtocolSiteUrl = config.siteUrl.replace(/^https?:\/\//i, "")
+    const siteUrl = stripLeadingTrailingSlashes(noProtocolSiteUrl)
     return `https://public-api.wordpress.com/wp/v2/sites/${siteUrl}`
   } else {
     return `${stripLeadingTrailingSlashes(config.siteUrl)}/wp-json/wp/v2`

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -5,6 +5,15 @@ import { log } from '../utilities/logger'
 
 let cacheManager = new CacheManager()
 
+const buildBaseUrl = config => {
+  if (config.options && config.options.wordpressDotComHosting) {
+    const siteUrl = stripLeadingTrailingSlashes(config.siteUrl)
+    return `https://public-api.wordpress.com/wp/v2/sites/${siteUrl}`
+  } else {
+    return `${stripLeadingTrailingSlashes(config.siteUrl)}/wp-json/wp/v2`
+  }
+}
+
 export default ({ server, config }) => {
 
   // Create a new cache | 100 requests only, expire after 2 minutes
@@ -21,7 +30,7 @@ export default ({ server, config }) => {
     },
     handler: (request, reply) => {
 
-      const base = `${stripLeadingTrailingSlashes(config.siteUrl)}/wp-json/wp/v2`
+      const base = buildBaseUrl(config)
       const path = `${request.params.query}${request.url.search}`
       const remote = `${base}/${path}`
       const cacheKey = stripLeadingTrailingSlashes(path)

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -2,11 +2,12 @@ import chalk from 'chalk'
 import fetch from 'isomorphic-fetch'
 import CacheManager, { stripLeadingTrailingSlashes } from '../utilities/cache-manager'
 import { log } from '../utilities/logger'
+import idx from 'idx'
 
 let cacheManager = new CacheManager()
 
 const buildBaseUrl = config => {
-  if (config.options && config.options.wordpressDotComHosting) {
+  if (idx(config, _ => _.options.wordpressDotComHosting)) {
     // Remove protocol
     const noProtocolSiteUrl = config.siteUrl.replace(/^https?:\/\//i, "")
     const siteUrl = stripLeadingTrailingSlashes(noProtocolSiteUrl)

--- a/src/utilities/validator.js
+++ b/src/utilities/validator.js
@@ -62,7 +62,9 @@ const schema = joi.object({
     // theme color for progress bar
     progressBarColor: joi.string(),
     // registers https Hapi plugin
-    forceHttps: joi.boolean()
+    forceHttps: joi.boolean(),
+    // Wordpress.com hosting configuration
+    wordpressDotComHosting: joi.boolean()
   })
 })
 

--- a/test/tests/wordpress-dot-com.test.js
+++ b/test/tests/wordpress-dot-com.test.js
@@ -47,7 +47,7 @@ describe('Handling server responses', () => {
       component: () => <p>Static endpoint</p>
     }
   ],
-    siteUrl: 'https://dummy.site.wordpress.com',
+    siteUrl: 'http://dummy.site.wordpress.com',
     options: {
       wordpressDotComHosting: true
     }
@@ -55,7 +55,7 @@ describe('Handling server responses', () => {
 
   before(done => {
     // mock api response
-    nock('http://public-api.wordpress.com')
+    nock('https://public-api.wordpress.com')
       .get('/wp/v2/sites/dummy.site.wordpress.com/posts/571')
       .times(1)
       .reply(200, dataPages.data)

--- a/test/tests/wordpress-dot-com.test.js
+++ b/test/tests/wordpress-dot-com.test.js
@@ -1,0 +1,161 @@
+import React from 'react'
+import { expect } from 'chai'
+import request from 'request'
+import nock from 'nock'
+
+import { bootServer } from '../utils'
+import dataPosts from '../mocks/posts.json'
+import dataPages from '../mocks/posts.json'
+
+
+describe('Handling server responses', () => {
+
+  let tapestry = null
+  let uri = null
+  let config = {
+    routes: [{
+      path: '/',
+      endpoint: 'posts?_embed',
+      component: () => <p>Hello</p>
+    },
+    {
+      path: '/:cat/:subcat/:id',
+      component: () => <p>Hello</p>
+    },
+    {
+      path: '/404-response',
+      endpoint: 'pages?slug=404-response',
+      component: () => <p>Hello</p>
+    }, {
+      path: '/empty-response',
+      endpoint: 'pages?slug=empty-response',
+      component: () => <p>Hello</p>
+    }, {
+      path: '/empty-allowed-response',
+      endpoint: 'pages?slug=empty-response',
+      options: { allowEmptyResponse: true },
+      component: () => <p>Hello</p>
+    }, {
+      path: '/object-endpoint',
+      endpoint: {
+        pages: 'pages',
+        posts: 'posts'
+      },
+      component: () => <p>Custom endpoint</p>
+    }, {
+      path: '/static-endpoint',
+      component: () => <p>Static endpoint</p>
+    }
+  ],
+    siteUrl: 'https://dummy.site.wordpress.com',
+    options: {
+      wordpressDotComHosting: true
+    }
+  }
+
+  before(done => {
+    // mock api response
+    nock('http://public-api.wordpress.com')
+      .get('/wp/v2/sites/dummy.site.wordpress.com/posts/571')
+      .times(1)
+      .reply(200, dataPages.data)
+      .get('/wp/v2/sites/dummy.site.wordpress.com/posts')
+      .times(1)
+      .reply(200, dataPages.data)
+      .get('/wp/v2/sites/dummy.site.wordpress.com/pages')
+      .times(1)
+      .reply(200, dataPosts.data)
+      .get('/wp/v2/sites/dummy.site.wordpress.com/posts?_embed')
+      .times(5)
+      .reply(200, dataPosts.data)
+      .get('/wp/v2/sites/dummy.site.wordpress.com/pages?slug=404-response')
+      .times(5)
+      .reply(404, { data: { status: 404 } })
+      .get('/wp/v2/sites/dummy.site.wordpress.com/pages?slug=empty-response')
+      .times(5)
+      .reply(200, [])
+    // boot tapestry server
+    process.env.CACHE_CONTROL_MAX_AGE=60
+    tapestry = bootServer(config)
+    tapestry.server.on('start', () => {
+      uri = tapestry.server.info.uri
+      done()
+    })
+  })
+
+  after(() => {
+    tapestry.server.stop()
+    delete process.env.CACHE_CONTROL_MAX_AGE
+  })
+
+  it('Route matched, status code is 200', (done) => {
+    request.get(uri, (err, res) => {
+      expect(res.statusCode).to.equal(200)
+      done()
+    })
+  })
+
+  it('Route matched, has correct headers', (done) => {
+    request.get(uri, (err, res) => {
+      expect(res.headers['content-type']).to.equal('text/html; charset=utf-8')
+      expect(res.headers['cache-control']).to.equal('max-age=60, must-revalidate, public')
+      done()
+    })
+  })
+
+  it('Preview routes send no-cache headers', (done) => {
+    request.get(`${uri}/foo/bar/571?tapestry_hash=somesortofhash&p=571`, (err, res) => {
+      expect(res.headers['content-type']).to.equal('text/html; charset=utf-8')
+      expect(res.headers['cache-control']).to.equal('no-cache')
+      done()
+    })
+  })
+
+  it('Route not matched, status code is 404', (done) => {
+    request
+      .get(`${uri}/route/not/matched/in/any/way`, (err, res) => {
+        expect(res.statusCode).to.equal(404)
+        done()
+      })
+  })
+
+  it('Route matched, API 404, status code is 404', (done) => {
+    request
+      .get(`${uri}/404-response`, (err, res) => {
+        expect(res.statusCode).to.equal(404)
+        done()
+      })
+  })
+
+  it('Route matched, API empty response, status code is 404', (done) => {
+    request
+      .get(`${uri}/empty-response`, (err, res) => {
+        expect(res.statusCode).to.equal(404)
+        done()
+      })
+  })
+
+  it('Route matched, API empty but allowed, status code is 200', (done) => {
+    request
+      .get(`${uri}/empty-allowed-response`, (err, res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+  })
+
+   it('Route matched, multiple API requests, status code is 200', (done) => {
+    request
+      .get(`${uri}/object-endpoint`, (err, res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+  })
+
+  it('Static route matched, no data loaded, status code is 200', (done) => {
+    request
+      .get(`${uri}/static-endpoint`, (err, res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+  })
+})

--- a/test/tests/wordpress-dot-com.test.js
+++ b/test/tests/wordpress-dot-com.test.js
@@ -8,7 +8,7 @@ import dataPosts from '../mocks/posts.json'
 import dataPages from '../mocks/posts.json'
 
 
-describe('Handling server responses', () => {
+describe('Handling server responses using Wordpress.com API', () => {
 
   let tapestry = null
   let uri = null
@@ -88,30 +88,14 @@ describe('Handling server responses', () => {
     delete process.env.CACHE_CONTROL_MAX_AGE
   })
 
-  it('Route matched, status code is 200', (done) => {
+  it('WP.com Route matched, status code is 200', (done) => {
     request.get(uri, (err, res) => {
       expect(res.statusCode).to.equal(200)
       done()
     })
   })
 
-  it('Route matched, has correct headers', (done) => {
-    request.get(uri, (err, res) => {
-      expect(res.headers['content-type']).to.equal('text/html; charset=utf-8')
-      expect(res.headers['cache-control']).to.equal('max-age=60, must-revalidate, public')
-      done()
-    })
-  })
-
-  it('Preview routes send no-cache headers', (done) => {
-    request.get(`${uri}/foo/bar/571?tapestry_hash=somesortofhash&p=571`, (err, res) => {
-      expect(res.headers['content-type']).to.equal('text/html; charset=utf-8')
-      expect(res.headers['cache-control']).to.equal('no-cache')
-      done()
-    })
-  })
-
-  it('Route not matched, status code is 404', (done) => {
+  it('WP.com Route not matched, status code is 404', (done) => {
     request
       .get(`${uri}/route/not/matched/in/any/way`, (err, res) => {
         expect(res.statusCode).to.equal(404)
@@ -119,7 +103,7 @@ describe('Handling server responses', () => {
       })
   })
 
-  it('Route matched, API 404, status code is 404', (done) => {
+  it('WP.com Route matched, API 404, status code is 404', (done) => {
     request
       .get(`${uri}/404-response`, (err, res) => {
         expect(res.statusCode).to.equal(404)
@@ -127,7 +111,7 @@ describe('Handling server responses', () => {
       })
   })
 
-  it('Route matched, API empty response, status code is 404', (done) => {
+  it('WP.com Route matched, API empty response, status code is 404', (done) => {
     request
       .get(`${uri}/empty-response`, (err, res) => {
         expect(res.statusCode).to.equal(404)
@@ -135,7 +119,7 @@ describe('Handling server responses', () => {
       })
   })
 
-  it('Route matched, API empty but allowed, status code is 200', (done) => {
+  it('WP.com Route matched, API empty but allowed, status code is 200', (done) => {
     request
       .get(`${uri}/empty-allowed-response`, (err, res) => {
         expect(res.statusCode).to.equal(200)

--- a/test/tests/wordpress-dot-com.test.js
+++ b/test/tests/wordpress-dot-com.test.js
@@ -7,7 +7,6 @@ import { bootServer } from '../utils'
 import dataPosts from '../mocks/posts.json'
 import dataPages from '../mocks/posts.json'
 
-
 describe('Handling server responses using Wordpress.com API', () => {
 
   let tapestry = null


### PR DESCRIPTION
#### What have you done
I've added  new configuration to the `tapestry.config.js` that allows you to use wordpress.com's free blog hosting to power Tapestry:

API endpoints are configured as such:
`https://public-api.wordpress.com/wp/v2/sites/en.blog.wordpress.com/`

Configuration looks like this:

```
{
  components: {
    Post: Post
  },
  siteUrl: 'http://dummy.site.wordpress.com',
  options: {
    wordpressDotComHosting: true
  }
}
```

#### Why have you done it
Really cool to support and it means you don't even need to pay to host a WordPress site, you can just get going with Tapestry straight away.

#### Testing carried out to prevent breaking changes
New tests written to check the data loading from those endpoints
