### PR TITLE
Feature/cache bust redirects json request

### DIFF
--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -34,7 +34,7 @@ export default ({ server, config }) => {
   }
 
   if (config.redirectsEndpoint) {
-    fetch(config.redirectsEndpoint)
+    fetch(`${config.redirectsEndpoint}?cacheBust=${Date.now()}`)
       .then(resp => {
         if (resp.status === 200) {
           return resp.json()

--- a/test/tests/redirects.test.js
+++ b/test/tests/redirects.test.js
@@ -38,6 +38,7 @@ describe('Handling redirects', () => {
 
     nock('http://dummy.api')
       .get('/web/app/uploads/redirects.json')
+      .query(true)
       .times(1)
       .reply(200, {'/redirect/from/endpoint': '/page'})
 
@@ -107,6 +108,7 @@ describe('Handling endpoint redirects', () => {
 
     nock('http://dummy.api')
       .get('/web/app/uploads/redirects.json')
+      .query(true)
       .times(1)
       .reply(200, dataRedirects)
 
@@ -127,6 +129,7 @@ describe('Handling endpoint redirects', () => {
 
     nock('http://dummy.api')
       .get('/web/app/uploads/redirects.json')
+      .query(true)
       .reply(404)
 
     // boot tapestry server
@@ -146,6 +149,7 @@ describe('Handling endpoint redirects', () => {
 
     nock('http://dummy.api')
       .get('/web/app/uploads/redirects.json')
+      .query(true)
       .reply(200, 'Error: <p>Something went wrong')
 
     // boot tapestry server


### PR DESCRIPTION
#### What have you done
Cache busting requests to the redirects.json endpoint

#### Why have you done it
It should probably be handled by the remote server, but we're getting lots of problems with cached responses.

#### Testing carried out to prevent breaking changes
Updated the tests.

_Attach screenshot if visual_
