### PR TITLE
!MERGE - Feature/cache manager

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2018,
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": true,

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
+  node:
+    version: 7.10.1
   environment:
-    YARN_VERSION: 0.18.1
+    YARN_VERSION: 0.27.5
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 dependencies:
   pre:

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">= 7.0.0",
-    "npm": ">= 4.2.0"
+    "node": ">= 7.6.0",
+    "npm": ">= 4.1.2"
   },
   "dependencies": {
     "assets-webpack-plugin": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   "bin": {
     "tapestry": "./bin/tapestry"
   },
+  "engineStrict": true,
   "engines": {
-    "node": ">= 7.10.0",
+    "node": ">= 7.0.0",
     "npm": ">= 4.2.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "tapestry": "./bin/tapestry"
   },
   "engines": {
-    "node": ">= 6.9.0",
-    "npm": ">= 3.10.0"
+    "node": ">= 7.10.0",
+    "npm": ">= 4.2.0"
   },
   "dependencies": {
     "assets-webpack-plugin": "^3.5.1",
@@ -52,6 +52,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",
     "babel-register": "^6.24.0",
+    "cache-manager": "^2.4.0",
     "chalk": "^1.1.3",
     "clean-webpack-plugin": "^0.1.16",
     "commander": "^2.9.0",
@@ -71,7 +72,6 @@
     "joi": "^10.4.1",
     "location-origin": "^1.1.4",
     "lodash": "^4.17.4",
-    "lru-cache": "^4.0.2",
     "mitt": "^1.1.0",
     "pretty-bytes": "^4.0.2",
     "prop-types": "^15.5.7",

--- a/src/server/handle-api.js
+++ b/src/server/handle-api.js
@@ -31,7 +31,7 @@ export default ({ server, config }) => {
         privacy: 'public'
       }
     },
-    handler: (request, reply) => {
+    handler: async (request, reply) => {
 
       const base = buildBaseUrl(config)
       const path = `${request.params.query}${request.url.search}`
@@ -39,7 +39,7 @@ export default ({ server, config }) => {
       const cacheKey = stripLeadingTrailingSlashes(path)
 
       // Look for a cached response - maybe undefined
-      const cacheRecord = cache.get(cacheKey)
+      const cacheRecord = await cache.get(cacheKey)
       log.debug(`Cache contains ${chalk.green(cacheKey)} in api: ${Boolean(cacheRecord)}`)
 
       // If we find a response in the cache send it back

--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -59,7 +59,7 @@ export default ({ server, config, assets }) => {
         loadContext.location = renderProps.location
 
         // get all the props yo
-        loadPropsOnServer(renderProps, loadContext, (err, asyncProps) => {
+        loadPropsOnServer(renderProps, loadContext, async (err, asyncProps) => {
           // 500 if error from AsyncProps
           if (err) {
             log.error(err)
@@ -78,7 +78,7 @@ export default ({ server, config, assets }) => {
           const cacheKey = stripLeadingTrailingSlashes(request.url.pathname)
 
           // Find HTML based on path - might be undefined
-          const cachedHTML = cache.get(cacheKey)
+          const cachedHTML = await cache.get(cacheKey)
           log.debug(`Cache contains ${chalk.green(cacheKey)} in html: ${Boolean(cachedHTML)}`)
 
           // respond with HTML from cache if not undefined

--- a/src/utilities/cache-manager.js
+++ b/src/utilities/cache-manager.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import LRU from 'lru-cache'
+import NCM from 'cache-manager'
 import { log } from '../utilities/logger'
 
 let internalCaches = []
@@ -25,17 +25,20 @@ export default class CacheManager {
   }
 
   createCache(name) {
-    internalCaches[name] = LRU({
-      max: parseInt(process.env.CACHE_MAX_ITEM_COUNT, 10) || 100,
-      maxAge: parseInt(process.env.CACHE_MAX_AGE, 10) || 1
+    const count = parseInt(process.env.CACHE_MAX_ITEM_COUNT, 10) || 100
+    const maxAge = parseInt(process.env.CACHE_MAX_AGE, 10) || 1
+    internalCaches[name] = NCM.caching({
+      store: 'memory',
+      max: count,
+      ttl: maxAge
     })
     return internalCaches[name]
   }
 
   clearAll() {
     if (internalCaches) {
-      internalCaches.forEach(cache =>
-        cache.reset()
+      internalCaches.forEach(async (cache) =>
+        await cache.reset()
       )
     }
   }
@@ -44,11 +47,11 @@ export default class CacheManager {
     return internalCaches[name]
   }
 
-  clearCache(cacheName, keyName) {
+  async clearCache(cacheName, keyName) {
 
     log.debug(`Cache cleared ${chalk.green(keyName)} in ${chalk.green(cacheName)}`)
     log.silly(JSON.stringify(internalCaches, null, 2))
 
-    internalCaches[cacheName].del(keyName)
+    await internalCaches[cacheName].del(keyName)
   }
 }

--- a/test/tests/cache.test.js
+++ b/test/tests/cache.test.js
@@ -58,12 +58,12 @@ describe('Handling cache purges', () => {
       expect(body).to.contain('Basic endpoint')
       expect(res.statusCode).to.equal(200)
 
-      request.get(`${uri}/purge/${route}`, (err, res, body) => {
+      request.get(`${uri}/purge/${route}`, async (err, res, body) => {
         const cacheApi = cacheManager.getCache('api')
         expect(body).to.contain(JSON.stringify(purgeResp))
         expect(res.statusCode).to.equal(200)
-        expect(cacheApi.keys()).to.not.contain('pages')
-
+        const result = await cacheApi.get('pages')
+        expect(result).to.be.undefined
         done()
       })
     })
@@ -77,12 +77,12 @@ describe('Handling cache purges', () => {
       expect(body).to.contain('Custom endpoint')
       expect(res.statusCode).to.equal(200)
 
-      request.get(`${uri}/purge/${route}`, (err, res, body) => {
+      request.get(`${uri}/purge/${route}`, async (err, res, body) => {
         const cacheApi = cacheManager.getCache('api')
         expect(body).to.contain(JSON.stringify(purgeResp))
         expect(res.statusCode).to.equal(200)
-        expect(cacheApi.keys()).to.not.contain('pages?slug=test')
-
+        const result = await cacheApi.get('pages?slug=test')
+        expect(result).to.be.undefined
         done()
       })
     })
@@ -96,11 +96,12 @@ describe('Handling cache purges', () => {
       expect(body).to.contain('Basic endpoint')
       expect(res.statusCode).to.equal(200)
 
-      request.get(`${uri}/purge/${route}`, (err, res, body) => {
+      request.get(`${uri}/purge/${route}`, async (err, res, body) => {
         const cacheApi = cacheManager.getCache('api')
         expect(body).to.contain(JSON.stringify(purgeResp))
         expect(res.statusCode).to.equal(200)
-        expect(cacheApi.keys()).to.not.contain('pages')
+        const result = await cacheApi.get('pages')
+        expect(result).to.be.undefined
 
         done()
       })
@@ -154,20 +155,24 @@ describe('Handling cache set/get', () => {
   })
 
   it('Sets API/HTML cache items correctly', done => {
-    request.get(uri, (err, res, body) => {
+    request.get(uri, async (err, res, body) => {
       const cacheApi = cacheManager.getCache('api')
       const cacheHtml = cacheManager.getCache('html')
-      expect(cacheApi.keys()).to.include('posts?_embed')
-      expect(cacheHtml.keys()).to.include('/')
+      const apiResult = await cacheApi.get('posts?_embed')
+      const htmlResult = await cacheHtml.get('/')
+      expect(apiResult).to.be.an('object').to.have.ownProperty('response')
+      expect(htmlResult).to.be.a('string').that.includes('doctype')
       done()
     })
   })
 
   it('Sets API/HTML cache items without query string', done => {
-    request.get(`${uri}/2017/12/01/query-test?utm_source=stop-it`, (err, res, body) => {
+    request.get(`${uri}/2017/12/01/query-test?utm_source=stop-it`, async (err, res, body) => {
       const cacheHtml = cacheManager.getCache('html')
-      expect(cacheHtml.keys()).to.include('2017/12/01/query-test')
-      expect(cacheHtml.keys()).to.not.include('2017/12/01/query-test?utm_source=stop-it')
+      const shouldCache = await cacheHtml.get('2017/12/01/query-test')
+      const shouldNotCache = await cacheHtml.get('2017/12/01/query-test?utm_source=stop-it')
+      expect(shouldCache).to.be.a('string').that.includes('doctype')
+      expect(shouldNotCache).to.be.undefined
       done()
     })
   })
@@ -198,13 +203,13 @@ describe('Handling cache set/get', () => {
     const cacheHtml = cacheManager.getCache('html')
     cacheHtml.reset()
 
-    request.get(`${uri}/2017/12/01/one-item`, () => {
-      expect(cacheHtml.keys()).to.have.length(1)
-      request.get(`${uri}/2017/12/01/another-item`, () => {
-        expect(cacheHtml.keys()).to.have.length(2)
-        request.get(`${uri}/2017/12/01/another-another-item`, () => {
-          expect(cacheHtml.keys()).to.have.length(2)
-          expect(cacheHtml.keys()).to.not.include('2017/12/01/one-item')
+    request.get(`${uri}/2017/12/01/one-item`, async () => {
+      expect(await cacheHtml.keys()).to.have.length(1)
+      request.get(`${uri}/2017/12/01/another-item`, async () => {
+        expect(await cacheHtml.keys()).to.have.length(2)
+        request.get(`${uri}/2017/12/01/another-another-item`, async () => {
+          expect(await cacheHtml.keys()).to.have.length(2)
+          expect(await cacheHtml.keys()).to.not.include('2017/12/01/one-item')
           done()
         })
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,7 +329,7 @@ async-some@~1.0.2:
   dependencies:
     dezalgo "^1.0.2"
 
-async@^1.3.0, async@^1.5.2:
+async@1.5.2, async@^1.3.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -1125,6 +1125,13 @@ cacache@^9.2.9, cacache@~9.2.9:
     ssri "^4.1.6"
     unique-filename "^1.1.0"
     y18n "^3.2.1"
+
+cache-manager@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/cache-manager/-/cache-manager-2.4.0.tgz#272e4eee3a4ecebb281fcb086499804e59a6a251"
+  dependencies:
+    async "1.5.2"
+    lru-cache "4.0.0"
 
 call-limit@~1.1.0:
   version "1.1.0"
@@ -4161,6 +4168,13 @@ loud-rejection@^1.0.0:
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lru-cache@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.0.tgz#b5cbf01556c16966febe54ceec0fb4dc90df6c28"
+  dependencies:
+    pseudomap "^1.0.1"
+    yallist "^2.0.0"
 
 lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.0.2, lru-cache@^4.1.1, lru-cache@~4.1.1:
   version "4.1.1"


### PR DESCRIPTION
I've used `async/await` in Node 7.6 (6 months old), to implement this quickly without refactoring much. Is this a breaking change to version 3? Potentially.... @thomasdigby Whaddya think, probably not many people using it beyond us, and I've update the package.json, so I think it would throw if you weren't using at least 7 to run it, technically it's not an API change. Not sure what semver says about this.

#### What have you done
I found the pluggable cache manager framework - rewritten the current caching implementation. It uses the new framework - and I'm hoping to add configuration via a cache.config.js (so nothing gets bundled in the frontend), which would allow a project to use any of the [flexible caching options availaibe in `node-cache-manager`](https://github.com/BryanDonovan/node-cache-manager#store-engines).

## Update - I'm just going to allow redis for now, multiple configuration a bit of a nightmare.

With the clustering functionality in https://github.com/shortlist-digital/tapestry-wp/pull/281, you'd be able to make sure each of your processes was accessing a central cache.

#### Why have you done it
Tapestry struggles as a single process in high-traffic deployments, clustering mitigates this, but the moments the HTML and API caches are isolated per process, so they're 1/[however-many-processes] you have as useful.

#### Testing carried out to prevent breaking changes
Refactored the tests.

_Attach screenshot if visual_
