### PR TITLE
Removed X-Frame-Options

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -27,8 +27,9 @@ export default class Tapestry {
 
     // Important bit:
     this.server.ext('onPreResponse', (request, reply) => {
-      request.response.headers &&
-        (request.response.headers['X-Powered-By'] = 'Tapestry')
+      if (request.response.headers) {
+        request.response.headers['X-Powered-By'] = 'Tapestry'
+      }
       reply.continue()
     })
 
@@ -75,11 +76,17 @@ export default class Tapestry {
     const server = new Server({
       connections: {
         router: {
-          stripTrailingSlash: true,
-          isCaseSensitive: false
+          isCaseSensitive: false,
+          stripTrailingSlash: true
         },
         routes: {
-          security: true
+          security: {
+            hsts: true,
+            noOpen: true,
+            noSniff: true,
+            xframe: false,
+            xss: true
+          }
         }
       }
     })


### PR DESCRIPTION
#### What have you done
Removed the X-Frame-Options header in the default security options.

#### Why have you done it
This option is too strict by default, it's required for us to render a site in FB IA. 

#### Testing carried out to prevent breaking changes
Tested the headers in browser