### PR TITLE
Move redirects handler to front of request queue to 'get them over with'

### DIFF
--- a/src/server/handle-redirects.js
+++ b/src/server/handle-redirects.js
@@ -4,14 +4,9 @@ import fetcher from '../shared/fetcher'
 import { log } from '../utilities/logger'
 
 const setRedirects = (server, redirects) => {
-  server.ext('onPostHandler', (request, reply) => {
-    const status = reply.request.response.statusCode
-    if (
-      (status === 404)
-      && redirects
-      // Tapestry only handles lowercase URLs
-      && (typeof redirects[request.url.pathname.toLowerCase()] !== "undefined")
-    ) {
+  server.ext('onPreHandler', (request, reply) => {
+    if (typeof redirects[request.url.pathname.toLowerCase()] !== "undefined")
+    {
       return reply
         .redirect(`${redirects[request.url.pathname]}${request.url.search}`)
         .permanent()


### PR DESCRIPTION
#### What have you done
I've moved the redirect handler from firing _after_ everything else has shaken out and a 404 is detected, to checking before each request.

v8 can read from an object with a key at a rate of ~100,000,000 operations per second, so this doesn't really affect performance.

#### Why have you done it
Redirects are failing some instances, probably because of incorrectly cached status codes - but there's actually no point detangling it. Keep it simple etc.

#### Testing carried out to prevent breaking changes
All the tests work.
